### PR TITLE
Allow the SDK to work with an existing access token

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -7,6 +7,7 @@ define(function() {
         authenticateOnStart: true,
         apiAuthenticateUrl: 'https://api.mendeley.com/oauth/authorize',
         accessTokenCookieName: 'accessToken',
+        accessToken: null,
         scope: 'all'
     };
 
@@ -31,6 +32,10 @@ define(function() {
      */
     function Auth(config) {
         this.config = config;
+        if (this.config.token) {
+            setAccessTokenCookie(this.config.token);
+            this.authenticate = $.noop;
+        }
     }
 
     Auth.TYPE_IMPLICIT = 'implicit';
@@ -53,7 +58,9 @@ define(function() {
      * @public
      */
     Auth.prototype.getToken = function () {
-        if (this.config.type === Auth.TYPE_IMPLICIT) {
+        if (this.config.token) {
+            return this.config.token;
+        } else if (this.config.type === Auth.TYPE_IMPLICIT) {
             return getAccessTokenCookieOrUrl();
         } else {
             return getAccessTokenCookie();
@@ -81,7 +88,8 @@ define(function() {
         settings = $.extend({}, defaults, defaultsImplicitFlow, options || {});
 
         var auth = new Auth({
-            type: Auth.TYPE_IMPLICIT
+            type: Auth.TYPE_IMPLICIT,
+            token: settings.accessToken
         });
 
         if (!settings.clientId) {
@@ -113,7 +121,8 @@ define(function() {
         settings = $.extend({}, defaults, defaultsAuthCodeFlow, options || {});
 
         var auth = new Auth({
-            type: Auth.TYPE_AUTHCODE
+            type: Auth.TYPE_AUTHCODE,
+            token: settings.accessToken
         });
 
         if (!settings.apiAuthenticateUrl) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -22,6 +22,55 @@ define(function() {
 
     var settings = {};
 
+    /**
+     * Auth Class
+     * @class Auth
+     * @constructor
+     * @param config {object}
+     * @param config.type {string}
+     */
+    function Auth(config) {
+        this.config = config;
+    }
+
+    Auth.TYPE_IMPLICIT = 'implicit';
+    Auth.TYPE_AUTHCODE = 'authcode';
+
+    /**
+     * @method authenticate
+     * @public
+     */
+    Auth.prototype.authenticate = function () {
+        var url = typeof settings.apiAuthenticateUrl === 'function' ?
+        settings.apiAuthenticateUrl() : settings.apiAuthenticateUrl;
+
+        clearAccessTokenCookie();
+        settings.win.location = url;
+    };
+
+    /**
+     * @method getToken
+     * @public
+     */
+    Auth.prototype.getToken = function () {
+        if (this.config.type === Auth.TYPE_IMPLICIT) {
+            return getAccessTokenCookieOrUrl();
+        } else {
+            return getAccessTokenCookie();
+        }
+    };
+
+    /**
+     * @method refreshToken
+     * @public
+     */
+    Auth.prototype.refreshToken = function () {
+        if (this.config.type === Auth.TYPE_IMPLICIT || !settings.refreshAccessTokenUrl) {
+            return false;
+        }
+        return $.get(settings.refreshAccessTokenUrl);
+    };
+
     return {
         implicitGrantFlow: implicitGrantFlow,
         authCodeFlow: authCodeFlow
@@ -30,6 +79,10 @@ define(function() {
     function implicitGrantFlow(options) {
 
         settings = $.extend({}, defaults, defaultsImplicitFlow, options || {});
+
+        var auth = new Auth({
+            type: Auth.TYPE_IMPLICIT
+        });
 
         if (!settings.clientId) {
             console.error('You must provide a clientId for implicit grant flow');
@@ -48,47 +101,31 @@ define(function() {
             '&scope=' + settings.scope +
             '&response_type=token';
 
-        if (settings.authenticateOnStart && !getAccessTokenCookieOrUrl()) {
-            authenticate();
+        if (settings.authenticateOnStart && !auth.getToken()) {
+            auth.authenticate();
         }
 
-        return {
-            authenticate: authenticate,
-            getToken: getAccessTokenCookieOrUrl,
-            refreshToken: noop()
-        };
+        return auth;
     }
 
     function authCodeFlow(options) {
 
         settings = $.extend({}, defaults, defaultsAuthCodeFlow, options || {});
 
+        var auth = new Auth({
+            type: Auth.TYPE_AUTHCODE
+        });
+
         if (!settings.apiAuthenticateUrl) {
             console.error('You must provide an apiAuthenticateUrl for auth code flow');
             return false;
         }
 
-        if (settings.authenticateOnStart && !getAccessTokenCookie()) {
-            authenticate();
+        if (settings.authenticateOnStart && !auth.getToken()) {
+            auth.authenticate();
         }
 
-        return {
-            authenticate: authenticate,
-            getToken: getAccessTokenCookie,
-            refreshToken: refreshAccessTokenCookie
-        };
-    }
-
-    function noop() {
-        return function() { return false; };
-    }
-
-    function authenticate() {
-        var url = typeof settings.apiAuthenticateUrl === 'function' ?
-            settings.apiAuthenticateUrl() : settings.apiAuthenticateUrl;
-
-        clearAccessTokenCookie();
-        settings.win.location = url;
+        return auth;
     }
 
     function getAccessTokenCookieOrUrl() {
@@ -143,13 +180,4 @@ define(function() {
     function clearAccessTokenCookie() {
         setAccessTokenCookie('', -1);
     }
-
-    function refreshAccessTokenCookie() {
-        if (settings.refreshAccessTokenUrl) {
-            return $.get(settings.refreshAccessTokenUrl);
-        }
-
-        return false;
-    }
 });
-

--- a/test/spec/auth/auth.spec.js
+++ b/test/spec/auth/auth.spec.js
@@ -66,6 +66,30 @@ define(function(require) {
                 expect(flow.refreshToken()).toBe(false);
             });
 
+            it('should NOT authenticate if a token has been provided in the options', function() {
+                var win = require('mocks/window')('a:', 'b', '/c');
+                var options = {win: win, clientId: 9999, accessToken: 'xxx', authenticateOnStart: true};
+
+                var flow = auth.implicitGrantFlow(options);
+                expect(win.location + '').toEqual('a://b/c');
+            });
+
+            it('should return the token that has been provided in the options', function() {
+                var win = require('mocks/window')();
+                var options = {win: win, clientId: 9999, accessToken: 'yyy', authenticateOnStart: true};
+
+                var flow = auth.implicitGrantFlow(options);
+                expect(flow.getToken()).toEqual('yyy');
+            });
+
+            it('should write the token provided in the options in a cookie', function () {
+                var win = require('mocks/window')();
+                var options = {win: win, clientId: 9999, accessToken: '777', authenticateOnStart: true};
+
+                auth.implicitGrantFlow(options);
+                expect(win.document.cookie).toMatch(/accessToken=777/);
+            });
+
         });
 
         describe('auth code flow', function() {
@@ -140,6 +164,29 @@ define(function(require) {
                 expect(ajaxRequest.url).toBe('/refresh');
             });
 
+            it('should NOT authenticate if a token has been provided in the options', function() {
+                var win = require('mocks/window')('x:', 'y', '/z');
+                var options = {win: win, clientId: 9999, accessToken: '123', authenticateOnStart: true};
+
+                var flow = auth.authCodeFlow(options);
+                expect(win.location + '').toEqual('x://y/z');
+            });
+
+            it('should return the token that has been provided in the options', function() {
+                var win = require('mocks/window')();
+                var options = {win: win, clientId: 9999, accessToken: '456', authenticateOnStart: true};
+
+                var flow = auth.authCodeFlow(options);
+                expect(flow.getToken()).toEqual('456');
+            });
+
+            it('should write the token provided in the options in a cookie', function () {
+                var win = require('mocks/window')();
+                var options = {win: win, clientId: 9999, accessToken: '789', authenticateOnStart: true};
+
+                auth.authCodeFlow(options);
+                expect(win.document.cookie).toMatch(/accessToken=789/);
+            });
         });
     });
 


### PR DESCRIPTION
This PR is a result of an experimental Chrome extension using the SDK.

### The Problem

A Chrome extension can be divided into smaller "modules" that live in their own isolated context, meaning that the access token cannot be shared across modules via a cookie.

### Suggested Solution

An access token can be given to the grant methods:

```javascript
implicitGrantFlow({
  accessToken: 1234
});
```

If a token exists, the grant methods won't start the authorisation process.

#### About the Auth class

The creation of the `Auth` class has been motivated by the fact that the two grant methods return the same interface. The `Auth` class puts together existing code and logic into one place. This allowed me to implement the logic around an existing token there and not in two different places.

### Comments

I'm not 100% happy with the solution I came up with but it's the simplest one out of many aborted refactoring attempts.

Perhaps this would have been better:?

```javascript
var token = 1234;
var SDK = MendeleySDK(token);
SDK.API.documents.list();
```

