### PR TITLE
Lint files before testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "example": "examples"
   },
   "scripts": {
+    "pretest": "./node_modules/.bin/jshint --config .jshintrc lib/*.js lib/api/*.js test/*.js test/mocks/*.js test/spec/**/*.js",
     "test": "node_modules/karma/bin/karma start",
     "start": "node examples/app.js",
     "build-jsdoc": "node_modules/.bin/jsdoc -d docs/ lib/api.js",
@@ -28,6 +29,7 @@
     "cookie-parser": "^1.3.3",
     "express": "^4.9.5",
     "jsdoc": "^3.3.0-alpha9",
+    "jshint": "^2.8.0",
     "karma": "^0.12.23",
     "karma-chrome-launcher": "^0.1.4",
     "karma-coverage": "^0.2.6",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "example": "examples"
   },
   "scripts": {
-    "pretest": "./node_modules/.bin/jshint --config .jshintrc lib/*.js lib/api/*.js test/*.js test/mocks/*.js test/spec/**/*.js",
-    "test": "node_modules/karma/bin/karma start",
+    "lint": "./node_modules/.bin/jshint --config .jshintrc lib/*.js lib/api/*.js test/*.js test/mocks/*.js test/spec/**/*.js",
+    "test": "npm run lint && node_modules/karma/bin/karma start",
     "start": "node examples/app.js",
     "build-jsdoc": "node_modules/.bin/jsdoc -d docs/ lib/api.js",
     "build-dist": "./node_modules/.bin/webpack && ./node_modules/.bin/webpack --minify",

--- a/test/mocks/auth.js
+++ b/test/mocks/auth.js
@@ -1,30 +1,32 @@
 define(function() {
 
+    'use strict';
+
     return {
         mockImplicitGrantFlow: mockImplicitGrantFlow,
         mockAuthCodeFlow: mockAuthCodeFlow
-    }
+    };
 
     function mockImplicitGrantFlow() {
         var fakeToken = 'auth';
 
         return {
-            getToken: function() { return fakeToken },
+            getToken: function() { return fakeToken; },
             authenticate: function() { return false; },
             refreshToken: function () { return false; }
-        }
+        };
     }
 
     function mockAuthCodeFlow() {
         var fakeToken = 'auth';
 
         return {
-            getToken: function() { return fakeToken },
+            getToken: function() { return fakeToken; },
             authenticate: function() { return false; },
             refreshToken: function() {
                 fakeToken = 'auth-refreshed';
                 return $.Deferred().resolve();
             }
-        }
+        };
     }
 });

--- a/test/spec/api/annotations.spec.js
+++ b/test/spec/api/annotations.spec.js
@@ -1,3 +1,4 @@
+/* jshint camelcase: false */
 define(function(require) {
 
     'use strict';
@@ -278,3 +279,4 @@ define(function(require) {
         });
     });
 });
+/* jshint camelcase: true */

--- a/test/spec/api/files.spec.js
+++ b/test/spec/api/files.spec.js
@@ -1,3 +1,4 @@
+/* jshint sub: true */
 define(function(require) {
 
     'use strict';
@@ -171,3 +172,4 @@ define(function(require) {
         });
     });
 });
+/* jshint sub: false */

--- a/test/spec/api/metadata.spec.js
+++ b/test/spec/api/metadata.spec.js
@@ -1,3 +1,4 @@
+/* jshint sub: true */
 define(function(require) {
 
     'use strict';
@@ -57,3 +58,4 @@ define(function(require) {
 
     });
 });
+/* jshint sub: false */

--- a/test/spec/api/profiles.spec.js
+++ b/test/spec/api/profiles.spec.js
@@ -1,3 +1,4 @@
+/* jshint camelcase: false */
 define(function(require) {
 
     'use strict';
@@ -111,3 +112,4 @@ define(function(require) {
     });
 
 });
+/* jshint camelcase: true */


### PR DESCRIPTION
I noticed that `.jshintrc` wasn't enforced :scream_cat: 

- [x] Added jshint as a dev dependency
- [x] Added a `pretest` step that lints all the JavaScript files prior to running the tests
- [x] Fixed several files that were not complying with the rules or that needed some exceptions (e.g. `document_id` not being written in camel case)