### PR TITLE
Using new /macro/folder_documents API endpoint (WL-395)

### DIFF
--- a/lib/api/documents.js
+++ b/lib/api/documents.js
@@ -17,7 +17,7 @@ define(['../utilities'], function(utils) {
             },
 
             listDocuments = utils.requestFun('GET', '/documents/'),
-            listFolder = utils.requestFun('GET', '/folders/{id}/documents', ['id']);
+            listFolder = utils.requestFun('GET', '/macro/folder_documents');
 
         return {
 
@@ -91,16 +91,9 @@ define(['../utilities'], function(utils) {
              * @returns {promise}
              */
             list: function(params) {
-                if (!params || typeof params.folderId === 'undefined') {
-                    return listDocuments.call(this, params);
-                } else {
-                    var folderId = params.folderId,
-                        callParams = {
-                            limit: params.limit
-                        };
-                    delete params.folderId;
-                    return listFolder.call(this, folderId, callParams);
-                }
+                /* jshint camelcase: false */
+                var list = (!params || typeof params.folder_id === 'undefined') ? listDocuments : listFolder;
+                return list.call(this, params);
             },
 
             /**

--- a/test/spec/api/documents.spec.js
+++ b/test/spec/api/documents.spec.js
@@ -387,14 +387,15 @@ define(function(require) {
 
         });
 
-        describe('list with folderId param', function() {
+        describe('list with folder_id param', function() {
+            /* jshint camelcase: false */
 
             var ajaxRequest;
             var params = {
                 sort: 'created',
                 order: 'desc',
                 limit: 50,
-                folderId: 'xyz'
+                folder_id: 'xyz'
             };
 
             it('should use the folders API', function() {
@@ -408,12 +409,8 @@ define(function(require) {
                 expect(ajaxRequest.type).toBe('GET');
             });
 
-            it('should use endpoint /folders/{id}/documents', function() {
-                expect(ajaxRequest.url).toBe(baseUrl + '/folders/xyz/documents');
-            });
-
-            it('should remove the all paramaters except limit', function() {
-                expect(ajaxRequest.data).toEqual({limit: 50});
+            it('should use endpoint /macro/folder_documents', function() {
+                expect(ajaxRequest.url).toBe(baseUrl + '/macro/folder_documents');
             });
 
         });


### PR DESCRIPTION
Getting a list of documents with a folder id will now use the new /macro/folder_documents API endpoint instead of /folders/{id}/documents, which responds with only ids. This avoids the need to make individual requests for each of the documents in the folder.

This is backwards breaking because `api.documents.list` now expects a `folder_id` instead of a `folderId` property.

The response is not backwards breaking. The promise still resolves with an array of objects containing an `id` property, but the objects now include various other document metadata.