### PR TITLE
Getting an institution's parent and child institutions

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -22,6 +22,7 @@ define(function(require) {
         followers: require('./api/followers')(),
         groups: require('./api/groups')(),
         institutions: require('./api/institutions')(),
+        institutionTrees: require('./api/institution-trees')(),
         locations: require('./api/locations')(),
         metadata: require('./api/metadata')(),
         profiles: require('./api/profiles')(),

--- a/lib/api/institution-trees.js
+++ b/lib/api/institution-trees.js
@@ -12,7 +12,7 @@ define(['../utilities'], function(utils) {
         return {
 
             /**
-             * Return an institution's entire tree
+             * Return all institution trees that the given institution is a member of
              *
              * @method
              * @memberof api.institution_trees
@@ -22,7 +22,7 @@ define(['../utilities'], function(utils) {
             list: utils.requestFun('GET', '/institution_trees'),
 
             /**
-             * Return the child nodes of an institution
+             * Return only the child nodes of a given institution
              *
              * @method
              * @memberof api.institution_trees

--- a/lib/api/institution-trees.js
+++ b/lib/api/institution-trees.js
@@ -1,0 +1,37 @@
+define(['../utilities'], function(utils) {
+
+    'use strict';
+
+    /**
+     * Institution trees API
+     *
+     * @namespace
+     * @name api.institutionTrees
+     */
+    return function institutionTrees() {
+        return {
+
+            /**
+             * Return an institution's entire tree
+             *
+             * @method
+             * @memberof api.institution_trees
+             * @param {object} params - An institution ID
+             * @returns {promise}
+             */
+            list: utils.requestFun('GET', '/institution_trees'),
+
+            /**
+             * Return the child nodes of an institution
+             *
+             * @method
+             * @memberof api.institution_trees
+             * @param {string} id - An institution ID
+             * @returns {promise}
+             */
+            retrieve: utils.requestFun('GET', '/institution_trees/{id}', ['id'])
+
+        };
+    };
+
+});

--- a/test/spec/api/institution-trees.spec.js
+++ b/test/spec/api/institution-trees.spec.js
@@ -1,0 +1,91 @@
+define(function(require) {
+
+    'use strict';
+
+    require('es5-shim');
+
+    describe('institution trees api', function() {
+
+        var api = require('api');
+        var institutionTreesApi = api.institutionTrees;
+        var baseUrl = 'https://api.mendeley.com';
+
+        var mockAuth = require('mocks/auth');
+        api.setAuthFlow(mockAuth.mockImplicitGrantFlow());
+
+        describe('list method', function() {
+            var ajaxSpy;
+            var ajaxRequest;
+            var params = {
+                institution_id: '123'
+            };
+            
+             beforeEach(function() {
+                ajaxSpy = spyOn($, 'ajax').and.returnValue($.Deferred().resolve());
+                institutionTreesApi.list(params);
+                expect(ajaxSpy).toHaveBeenCalled();
+                ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
+            });
+
+            it('should be defined', function() {
+                expect(typeof institutionTreesApi.list).toBe('function');
+            });
+
+            it('should use GET', function() {
+                expect(ajaxRequest.type).toBe('GET');
+            });
+
+            it('should use endpoint /institution_trees', function() {
+                expect(ajaxRequest.url).toBe(baseUrl + '/institution_trees');
+            });
+
+            it('should NOT have a Content-Type header', function() {
+                expect(ajaxRequest.headers['Content-Type']).not.toBeDefined();
+            });
+
+            it('should have an Authorization header', function() {
+                expect(ajaxRequest.headers.Authorization).toBeDefined();
+                expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
+            });
+
+            it('should allow parameters', function() {
+                expect(ajaxRequest.data).toEqual(params);
+            });
+
+        });
+
+        describe('retrieve method', function() {
+            var ajaxSpy;
+            var ajaxRequest;
+            
+            beforeEach(function() {
+                ajaxSpy = spyOn($, 'ajax').and.returnValue($.Deferred().resolve());
+                institutionTreesApi.retrieve('123');
+                expect(ajaxSpy).toHaveBeenCalled();
+                ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
+            });
+
+            it('should be defined', function() {
+                expect(typeof institutionTreesApi.retrieve).toBe('function');
+            });
+
+            it('should use GET', function() {
+                expect(ajaxRequest.type).toBe('GET');
+            });
+
+            it('should use endpoint /institution_trees/123', function() {
+                expect(ajaxRequest.url).toBe(baseUrl + '/institution_trees/123');
+            });
+
+            it('should NOT have a Content-Type header', function() {
+                expect(ajaxRequest.headers['Content-Type']).not.toBeDefined();
+            });
+
+            it('should have an Authorization header', function() {
+                expect(ajaxRequest.headers.Authorization).toBeDefined();
+                expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
+            });
+        });
+    });
+});
+


### PR DESCRIPTION
When searching for an institution by name, what's returned can often be a department within the desired institution, rather than the desired institution itself. Support for the tree endpoint helps provide parent/child information to the user.