### PR TITLE
Allow custom content type with file upload

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -170,7 +170,7 @@ define(['./request'], function(Request) {
             var url = getUrl(uriTemplate, [], args);
             var file = args[0];
             var linkId = args[1];
-            var requestHeaders = $.extend(true, {}, headers, getRequestHeaders(uploadHeaders(file, linkId, linkType), method));
+            var requestHeaders = $.extend(true, {}, getRequestHeaders(uploadHeaders(file, linkId, linkType), method), headers);
             var request = {
                 type: method,
                 url: url,

--- a/test/spec/api/institution-trees.spec.js
+++ b/test/spec/api/institution-trees.spec.js
@@ -14,6 +14,7 @@ define(function(require) {
         api.setAuthFlow(mockAuth.mockImplicitGrantFlow());
 
         describe('list method', function() {
+            /* jshint camelcase: false */
             var ajaxSpy;
             var ajaxRequest;
             var params = {

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -1,0 +1,36 @@
+define(function(require) {
+
+    'use strict';
+
+    describe('utilities', function() {
+
+        var utils = require('utilities');
+        var mockAuth = require('mocks/auth');
+        utils.setAuthFlow(mockAuth.mockImplicitGrantFlow());
+
+        describe('requestWithFileFun', function() {
+
+            var ajaxSpy;
+
+            beforeEach(function() {
+                ajaxSpy = spyOn($, 'ajax').and.returnValue($.Deferred().resolve());
+            });
+
+            it('should allow a custom content-type to be set against a request', function() {
+                var file = {
+                    name: 'fileName',
+                    type: 'text/plain'
+                };
+                var requestFunction = utils.requestWithFileFun('POST', 'url', 'link', {
+                    'Content-Type': 'text/html'
+                });
+
+                requestFunction(file);
+                expect(ajaxSpy.calls.mostRecent().args[0].headers['Content-Type']).toBe('text/html');
+            });
+
+        });
+
+    });
+});
+


### PR DESCRIPTION
Strictly speaking this is a backwards breaking change, so probably warrants a major bump. However, it's unlikely to affect anyone since this is fixing a bug.

With this PR, it is possible to set a custom Content-Type header on file upload requests using `utilities.requestWithFileFun`. Without this PR, the Content-Type header always corresponds with the `type` property of the file.