### PR TITLE
Fix authorization code flow example 

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -190,7 +190,7 @@ var getFiles = function (event) {
                     // Auth code flow can be configured with a couple fo extra URLs...
                     MendeleySDK.API.setAuthFlow(MendeleySDK.Auth.authCodeFlow({
                         // The API authentication goes through server, so this URL clears cookies and forces a redirect
-                        apiAuthenticateUrl: '/logout',
+                        apiAuthenticateUrl: '/login',
                         // You can optionally provide a URL on *your* server where the token can be refreshed
                         refreshAccessTokenUrl: '/oauth/refresh'
                     }));

--- a/examples/oauth-app.js
+++ b/examples/oauth-app.js
@@ -30,7 +30,7 @@ module.exports = function(app, config) {
     });
 
     app.get(oauthPath, function (req, res) {
-        var authorizationUri = oauth2.AuthCode.authorizeURL({
+        var authorizationUri = oauth2.authCode.authorizeURL({
             redirect_uri: config.redirectUri,
             scope: config.scope || 'all'
         });
@@ -42,7 +42,7 @@ module.exports = function(app, config) {
     app.get(tokenExchangePath, function (req, res, next) {
         console.log('Starting token exchange');
         var code = req.query.code;
-        oauth2.AuthCode.getToken({
+        oauth2.authCode.getToken({
             redirect_uri: config.redirectUri,
             code: code,
         }, function(error, result) {


### PR DESCRIPTION
Fix authorization code flow example by changing the `apiAuthenticateUrl` to `login` and fixing oauth2 attribute name from `AuthCode` to `authCode`