### PR TITLE
Make sure that refreshToken() for the implicit grant flow is an actual noop function

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -24,7 +24,8 @@ define(function() {
 
     return {
         implicitGrantFlow: implicitGrantFlow,
-        authCodeFlow: authCodeFlow
+        authCodeFlow: authCodeFlow,
+        noop: noop
     };
 
     function implicitGrantFlow(options) {
@@ -55,7 +56,7 @@ define(function() {
         return {
             authenticate: authenticate,
             getToken: getAccessTokenCookieOrUrl,
-            refreshToken: noop()
+            refreshToken: noop
         };
     }
 
@@ -80,7 +81,7 @@ define(function() {
     }
 
     function noop() {
-        return function() { return false; };
+        // there is nothing here on purpose
     }
 
     function authenticate() {

--- a/test/spec/auth/auth.spec.js
+++ b/test/spec/auth/auth.spec.js
@@ -63,7 +63,7 @@ define(function(require) {
                 var options = {win: win, clientId: 9999, refreshAccessTokenUrl: '/refresh'};
 
                 var flow = auth.implicitGrantFlow(options);
-                expect(flow.refreshToken()).toBe(false);
+                expect(flow.refreshToken).toBe(auth.noop);
             });
 
         });


### PR DESCRIPTION
By exporting a noop function in the `auth` module we can make sure that the
refreshToken implementation for the implicit grant flow isn't doing anything.

The current test was simply assuming that a returned value of false was
the signature of a noop function which isn't quite right as we could implement
a refreshToken method that can both do stuff and return false.