### PR TITLE
Add Travis CI build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,7 @@ Please note the aim of this SDK is to connect to the existing Mendeley API, not 
 [register your application]:http://dev.mendeley.com
 [nodejs]:http://nodejs.org
 [bower]:http://bower.io
+
+## Build status
+
+![Travis CI](https://travis-ci.org/Mendeley/mendeley-javascript-sdk.svg?branch=master)


### PR DESCRIPTION
The setup for Travis had been done in a previous PR but Travis was never actually enabled to build it. The switch has now been flicked, and this PR adds the build status badge to the repo's README.