### PR TITLE
Accept header changes

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -33,8 +33,10 @@ define(function() {
 
         dfd = dfd || $.Deferred();
         request = request || this.request;
-        request.headers = request.headers || {};
-        var token = this.settings.authFlow.getToken();
+
+        var token = this.settings.authFlow.getToken(),
+            headers = $.extend({ Accept: '' }, request.headers);
+
         // If no token at all (cookie deleted or expired) refresh token if possible or authenticate
         // because if you send 'Bearer ' you get a 400 rather than a 401 - is that a bug in the api?
         if (!token) {
@@ -44,6 +46,7 @@ define(function() {
             return dfd.promise();
         }
 
+        request.headers = headers;
         request.headers.Authorization = 'Bearer ' + token;
 
         if (this.settings.fileUpload) {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -84,9 +84,10 @@ define(['./request'], function(Request) {
      *
      * @private
      * @param {string} rel - One of "next", "prev" or "last"
+     * @param {object} headers
      * @returns {function}
      */
-    function requestPageFun(rel) {
+    function requestPageFun(rel, headers) {
 
         return function() {
             if (!this.paginationLinks[rel]) {
@@ -97,7 +98,7 @@ define(['./request'], function(Request) {
                 type: 'GET',
                 dataType: 'json',
                 url: this.paginationLinks[rel],
-                headers: getRequestHeaders({})
+                headers: getRequestHeaders(headers || {})
             };
 
             var settings = {

--- a/test/spec/request/request.spec.js
+++ b/test/spec/request/request.spec.js
@@ -95,9 +95,9 @@ define(function(require) {
                     expect(authRefreshSpy.calls.count()).toEqual(1);
                     expect(mockNotifier.calls.count()).toEqual(3);
                     expect(mockNotifier.calls.allArgs()).toEqual([
-                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Authorization : 'Bearer auth' } } ],
-                        ['authWarning', [ 401, 1, 2 ], { type : 'GET', headers : { Authorization : 'Bearer auth' } }, { status : 401 } ],
-                        ['refreshError', [500], { type : 'GET', headers : { Authorization : 'Bearer auth' } }, { status : 500 }  ]
+                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } } ],
+                        ['authWarning', [ 401, 1, 2 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } }, { status : 401 } ],
+                        ['refreshError', [500], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } }, { status : 500 }  ]
                         ]);
                     done();
                     });
@@ -116,8 +116,8 @@ define(function(require) {
                     expect(authRefreshSpy.calls.count()).toEqual(1);
                     expect(mockNotifier.calls.count()).toEqual(3);
                     expect(mockNotifier.calls.allArgs()).toEqual([
-                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Authorization : 'Bearer auth' } } ],
-                        ['authWarning', [ 401, 1, 2 ], { type : 'GET', headers : { Authorization : 'Bearer auth' } }, { status : 401 } ],
+                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } } ],
+                        ['authWarning', [ 401, 1, 2 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } }, { status : 401 } ],
                         ['refreshNotConfigured', [] ]
                         ]);
                     done();
@@ -157,10 +157,10 @@ define(function(require) {
 
                     expect(mockNotifier.calls.count()).toEqual(4);
                     expect(mockNotifier.calls.allArgs()).toEqual([
-                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Authorization : 'Bearer auth-refreshed' } } ],
-                        ['authWarning', [ 401, 1, 2 ], { type : 'GET', headers : { Authorization : 'Bearer auth-refreshed' } }, { status : 401 } ],
-                        ['authWarning', [ 401, 2, 2 ], { type : 'GET', headers : { Authorization : 'Bearer auth-refreshed' } }, { status : 401 } ],
-                        ['authError', [ 401, 2 ], { type : 'GET', headers : { Authorization : 'Bearer auth-refreshed' } }, { status : 401 } ]
+                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth-refreshed' } } ],
+                        ['authWarning', [ 401, 1, 2 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth-refreshed' } }, { status : 401 } ],
+                        ['authWarning', [ 401, 2, 2 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth-refreshed' } }, { status : 401 } ],
+                        ['authError', [ 401, 2 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth-refreshed' } }, { status : 401 } ]
                         ]);
                     done();
                 });
@@ -243,10 +243,10 @@ define(function(require) {
 
                     expect(mockNotifier.calls.count()).toEqual(4);
                     expect(mockNotifier.calls.allArgs()).toEqual([
-                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Authorization : 'Bearer auth' } } ],
-                        ['commWarning', [ 504, 1, 2 ], { type : 'GET', headers : { Authorization : 'Bearer auth' } }, { status : 504 } ],
-                        ['commWarning', [ 504, 2, 2 ], { type : 'GET', headers : { Authorization : 'Bearer auth' } }, { status : 504 } ],
-                        ['commError', [ 504, 2 ], { type : 'GET', headers : { Authorization : 'Bearer auth' } }, { status : 504 } ]
+                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } } ],
+                        ['commWarning', [ 504, 1, 2 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } }, { status : 504 } ],
+                        ['commWarning', [ 504, 2, 2 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } }, { status : 504 } ],
+                        ['commError', [ 504, 2 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } }, { status : 504 } ]
                         ]);
                     done();
                 });
@@ -280,8 +280,8 @@ define(function(require) {
 
                     expect(mockNotifier.calls.count()).toEqual(2);
                     expect(mockNotifier.calls.allArgs()).toEqual([
-                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Authorization : 'Bearer auth' } } ],
-                        ['reqError', [ 404 ], { type : 'GET', headers : { Authorization : 'Bearer auth' } }, { status : 404 } ]
+                        ['startInfo', [ 'GET', undefined ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } } ],
+                        ['reqError', [ 404 ], { type : 'GET', headers : { Accept: '', Authorization : 'Bearer auth' } }, { status : 404 } ]
                         ]);
                     done();
                 });


### PR DESCRIPTION
> For /v{N} endpoints the Content-Type and Accept headers will be mandatory where a body is transferred; wildcarded headers will also be forbidden. This is to ensure that we do not break clients by introducing a new content type for the same version and inadvertently sending a response in a format that is not compatible as might have happened in the previous versioning strategy. The API proxy will reject requests (returning a 406 status code) that do not include a valid Content-Type/Accept header. Some clients by default specify a wildcard if no Accept header is specified, in these instances clients will have to specify an Accept header with a blank content to indicate they are not expecting any content.

To be honest - I'm not sure if this will not break any of currently used endpoints, so I would be very, very grateful if someone could check this branch in their projects and see if everything is fine.

If sone of the endpoints stopped working it mean that we should explicitly add Accept header, so note here endpoints that stopped working for you and I will figure out which content type should be in the headers.

Thanks for you generous co-operation.