### PR TITLE
Fix jsdoc command-line to include all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "./node_modules/.bin/jshint --config .jshintrc lib/*.js lib/api/*.js test/mocks/*.js test/spec/**/*.js",
     "test": "npm run lint && node_modules/.bin/serial-jasmine test/spec/**/*.spec.js test/spec/*.spec.js && node_modules/karma/bin/karma start --single-run",
     "start": "node examples/app.js",
-    "build-jsdoc": "node_modules/.bin/jsdoc -d docs/ lib/api.js",
+    "build-jsdoc": "node_modules/.bin/jsdoc -d docs/ lib/*.js lib/*/*.js",
     "build-dist": "./node_modules/.bin/webpack && ./node_modules/.bin/webpack --minify",
     "release-patch": "./node_modules/.bin/mversion patch --no-prefix -m 'Released patch version v%s'",
     "release-minor": "./node_modules/.bin/mversion minor --no-prefix -m 'Released minor version v%s'",


### PR DESCRIPTION
Until now, only docs for `api.js` were being generated.
This should fix issue #38 .