### PR TITLE
Including entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "directories": {
     "example": "examples"
   },
+  "main": "lib/index.js",
   "scripts": {
     "lint": "./node_modules/.bin/jshint --config .jshintrc lib/*.js lib/api/*.js test/mocks/*.js test/spec/**/*.js",
     "test": "npm run lint && node_modules/.bin/serial-jasmine test/spec/**/*.spec.js test/spec/*.spec.js && node_modules/karma/bin/karma start --single-run",


### PR DESCRIPTION
This is so clients can require('mendeley-javascript-sdk') or import without having to specify the path to the entry point.