### PR TITLE
Remove GET retries

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -72,10 +72,6 @@ function requestFun(responseFilter, method, uriTemplate, uriVars, headers) {
             authFlow: authFlow
         };
 
-        if (method === 'GET') {
-            settings.maxRetries = 1;
-        }
-
         var promise = Request.create(request, settings).send();
         
         return promise.then(function(response) {


### PR DESCRIPTION
Either retries should be configurable or we should be able to write
our own retry logic.

Having the above code forces sdk user to retry even number of times.