### PR TITLE
Allow multiple instances of the api to coexist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ examples/config.js
 examples/oauth-config.js
 examples/oauth-config.implicit-grant.js
 examples/oauth-config.auth-code.js
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 The SDK provides a convenient library for accessing the Mendeley API with client-side and server-side JavaScript.
 
-
 ## Installation
 
 Installation can be done with [bower][]:
@@ -51,9 +50,12 @@ To begin a session you must set an authentication flow. This SDK includes code f
 For purely client-side applications you can use the implicit grant flow which only requires a client id. To initiate the flow call:
 
 ```javascript
-var options = { clientId: /* YOUR CLIENT ID */ };
-var auth = MendeleySDK.Auth.implicitGrantFlow(options);
-MendeleySDK.API.setAuthFlow(auth);
+var sdk = require('mendeley-javascript-sdk');
+var api = sdk({
+  authFlow: sdk.Auth.implicitGrantFlow({
+    clientId: /* YOUR CLIENT ID */
+  })
+});
 ```
 
 The options are:
@@ -71,12 +73,13 @@ For server applications you can use the authorization code flow. This requires s
 The main difference is the server will do the token exchange and set the access token cookie. From the client-side point of view you start the flow like:
 
 ```javascript
-var options = {
+var sdk = require('mendeley-javascript-sdk');
+var api = sdk({
+  authFlow: sdk.Auth.authCodeFlow({
     apiAuthenticateUrl: '/login',
     refreshAccessTokenUrl: '/refresh-token'
-};
-var auth = MendeleySDK.Auth.authCodeFlow(options);
-MendeleySDK.API.setAuthFlow(auth);
+  })
+});
 ```
 
 The options are:
@@ -89,12 +92,12 @@ The options are:
 
 Once the OAuth flow is complete you can start grabbing data for the user. CORS is enabled by default for all clients so there's no need to do anything special to implement the cross-domain requests (unless you need to support browsers that don't have CORS).
 
-Each API is exposed as a property of the SDK, for example `MendeleySDK.API.documents`, `MendeleySDK.API.folders`.
+Each API is exposed as a property of the SDK, for example `api.documents`, `api.folders`.
 
 Methods that make API calls return [Bluebird promises][]. Each call will either resolve with some data or reject with a response object according to the response from [axios][]. Here's an example using the standalone version:
 
 ```javascript
-MendeleySDK.API.documents.list().then(function(docs) {
+api.documents.list().then(function(docs) {
 
     console.log('Success!');
     console.log(docs);
@@ -135,7 +138,7 @@ The API endpoint objects (e.g. ```MendeleySDK.API.documents```) store their pagi
 
 Example
 ```javascript
-var api = require('mendeley-javascript-sdk/lib/api');
+var api = require('mendeley-javascript-sdk')(options);
 
 api.documents.list().then(function (result) {
     // handle the first page of "My documents"
@@ -157,7 +160,7 @@ To avoid this behavior, every endpoint object allows using separate instances of
 
 Example
 ```javascript
-var api = require('mendeley-javascript-sdk/lib/api');
+var api = require('mendeley-javascript-sdk')(options);
 
 // a new instance of api.documents is created under the hood and returned
 var myDocumentsApi = api.documents.for('my_documents');
@@ -197,7 +200,7 @@ passed to the ```list()``` method.
 
 Example
 ```javascript
-var api = require('mendeley-javascript-sdk/lib/api');
+var api = require('mendeley-javascript-sdk')(options);
 
 var params = {
     group_id: 'zxc-876-cbm',

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,46 +3,65 @@ Upgrading to v3.x
 
 This version introduces some breaking changes that will effect client applications. These six breaking changes are approximately in order of impact.
 
-1.
-All SDK methods now return Bluebird promises instead of jQuery promises. It is therefore no longer possible to assign handlers with .done(), .fail(), 
+1.  All SDK methods now return Bluebird promises instead of jQuery promises. It is therefore no longer possible to assign handlers with .done(), .fail(),
 or .always() - you must use .then(), .catch(), and .finally()
 
-Because promises do not support progress handlers, these are now passed as a callback to the SDK method call as follows:
+  Because promises do not support progress handlers, these are now passed as a callback to the SDK method call as follows:
 
+    ```javascript
     api.documents.createFromFile(file, function progressHandler() { ... });
+    ```
 
-Some synchronous tests might be effected by this because unlike jQuery promises, Bluebird promises are completely asynchronous. When stubbing SDK methods, ensure you now return Bluebird promises instead of jQuery Deferreds.
-e.g. in Jasmine:
+  Some synchronous tests might be effected by this because unlike jQuery promises, Bluebird promises are completely asynchronous. When stubbing SDK methods, ensure you now return Bluebird promises instead of jQuery Deferreds.
 
+  e.g. in Jasmine:
+
+    ```javascript
     spyOn(api.documents, 'create').and.returnValue($.Deferred().resolve());
     // becomes
     spyOn(api.documents, 'create').and.returnValue(Bluebird.resolve());
+    ```
 
-2.
-The .then() success handler now only gets one parameter - the data returned by
+1. The .then() success handler now only gets one parameter - the data returned by
 the API call. Unless specified, headers and other xhr properties will not be accessible.
 
-3.
-The SDK relies on a Promise implementation being present in the environment.
+1. The SDK relies on a Promise implementation being present in the environment.
 Depending on your target browsers, you may need to polyfill the Promise global.
 For projects using Webpack, include the following plugin in your config:
 
+    ```javascript
     {
         plugins: [new webpack.ProvidePlugin({
             Promise: 'bluebird'
         })];
     }
+    ```
 
-You can use a different promise implementation here if desired.
+    You can use a different promise implementation here if desired.
 
-4.
-Because we're running everything in Node now, we're no longer using bower to manage dependencies. Unless you're using the precompiled bundle, you will need to move your sdk dependency from bower.json to package.json and install using npm now.
+1. Because we're running everything in Node now, we're no longer using bower to manage dependencies. Unless you're using the precompiled bundle, you will need to move your sdk dependency from bower.json to package.json and install using npm now.
 
-5.
-Because the SDK no longer uses jQuery at all, it will not be possible to assign
+1. Because the SDK no longer uses jQuery at all, it will not be possible to assign
 global AJAX config using `jQuery.ajaxSetup()`
 Use axios defaults instead:
 https://github.com/mzabriskie/axios#global-axios-defaults
 
-6.
-The notifier feature has been completely removed. All calls to `api.setNotifier()` will have to be removed from client codebases and anything relying on the events provided by this feature will have to be reworked.
+1. The notifier feature has been completely removed. All calls to `api.setNotifier()` will have to be removed from client codebases and anything relying on the events provided by this feature will have to be reworked.
+
+1. The `.API` property is now deprecated.  Instead you should call the result of `require` as a function and use that instance to make your API requests:
+
+    ```javascript
+    // old
+    var Mendeley = require('mendeley-javascript-sdk');
+    Mendeley.setAuthFlow(Mendeley.Auth.implicitGrantFlow(/* ... */))
+    Mendeley.API.documents.list().then(/* ... */)
+
+    // new
+    var mendeley = require('mendeley-javascript-sdk');
+    var api = mendeley({
+       authFlow: mendeley.Auth.implicitGrantFlow(/* ... */)
+    })
+    api.documents.list().then(/* ... */)
+    ```
+
+  Any attempt to access the `.API` object after creating an instance will result in an error being thrown.

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,6 +2,7 @@
 
 var assign = require('object-assign');
 var Bluebird = require('bluebird');
+var decorate = require('./decorate');
 
 Bluebird.config({
     warnings: false,
@@ -10,25 +11,6 @@ Bluebird.config({
 
 if (typeof process === 'object' && process + '' === '[object process]') {
     global.window = {};
-}
-
-function decorateWithFor(originalInstance, factory, options) {
-    var instanceMap = {};
-
-    originalInstance.for = function (mappingKey) {
-        if (!mappingKey) {
-            return originalInstance;
-        }
-
-        if (!instanceMap[mappingKey]) {
-            // create a new instance
-            instanceMap[mappingKey] = factory(options);
-        }
-
-        return instanceMap[mappingKey];
-    };
-
-    return originalInstance;
 }
 
 var endpointFactories = {
@@ -54,7 +36,7 @@ function createEndpoints (options) {
       var factory = endpointFactories[endpointName];
       var originalInstance = factory(options);
 
-      endpoints[endpointName] = decorateWithFor(originalInstance, factory, options);
+      endpoints[endpointName] = decorate(originalInstance, factory, options);
   });
 
   return endpoints;

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var utils = require('./utilities');
 var assign = require('object-assign');
 var Bluebird = require('bluebird');
 
@@ -13,7 +12,7 @@ if (typeof process === 'object' && process + '' === '[object process]') {
     global.window = {};
 }
 
-function decorateWithFor(originalInstance, factory) {
+function decorateWithFor(originalInstance, factory, options) {
     var instanceMap = {};
 
     originalInstance.for = function (mappingKey) {
@@ -23,7 +22,7 @@ function decorateWithFor(originalInstance, factory) {
 
         if (!instanceMap[mappingKey]) {
             // create a new instance
-            instanceMap[mappingKey] = factory();
+            instanceMap[mappingKey] = factory(options);
         }
 
         return instanceMap[mappingKey];
@@ -31,18 +30,6 @@ function decorateWithFor(originalInstance, factory) {
 
     return originalInstance;
 }
-
-/**
- * API
- *
- * @namespace
- * @name api
- */
-var methods = {
-    setAuthFlow: utils.setAuthFlow,
-    setBaseUrl:  utils.setBaseUrl,
-    decorateWithFor: decorateWithFor
-};
 
 var endpointFactories = {
     annotations: require('./api/annotations'),
@@ -60,13 +47,23 @@ var endpointFactories = {
     trash: require('./api/trash')
 };
 
-var endpoints = {};
+function createEndpoints (options) {
+  var endpoints = {};
 
-Object.keys(endpointFactories).forEach(function(endpointName) {
-    var factory = endpointFactories[endpointName];
-    var originalInstance = factory();
+  Object.keys(endpointFactories).forEach(function(endpointName) {
+      var factory = endpointFactories[endpointName];
+      var originalInstance = factory(options);
 
-    endpoints[endpointName] = decorateWithFor(originalInstance, factory);
-});
+      endpoints[endpointName] = decorateWithFor(originalInstance, factory, options);
+  });
 
-module.exports = assign(endpoints, methods);
+  return endpoints;
+}
+
+module.exports = function (options) {
+  var api = {};
+
+  assign(api, createEndpoints(options));
+
+  return api;
+};

--- a/lib/api/annotations.js
+++ b/lib/api/annotations.js
@@ -8,11 +8,11 @@ var utils = require('../utilities');
  * @namespace
  * @name api.annotations
  */
-module.exports = function annotations() {
+module.exports = function annotations(options) {
 
-	var dataHeaders = {
-		annotation: { 'Content-Type': 'application/vnd.mendeley-annotation.1+json' }
-	};
+    var dataHeaders = {
+        annotation: { 'Content-Type': 'application/vnd.mendeley-annotation.1+json' }
+    };
 
     return {
 
@@ -24,9 +24,15 @@ module.exports = function annotations() {
          * @param {string} id - Annotation UUID
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/annotations/{id}', ['id']),
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/annotations/{id}',
+            args: ['id']
+        }),
 
-		/**
+        /**
          * Patch a single annotation
          *
          * @method
@@ -35,7 +41,15 @@ module.exports = function annotations() {
          * @param {object} text - The updated note text
          * @returns {Promise}
          */
-        patch: utils.requestWithDataFun('PATCH', '/annotations/{id}', ['id'], dataHeaders.annotation, true),
+        patch: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'PATCH',
+            resource: '/annotations/{id}',
+            args: ['id'],
+            headers: dataHeaders.annotation,
+            followLocation: true
+        }),
 
         /**
          * Create a single annotation
@@ -45,7 +59,14 @@ module.exports = function annotations() {
          * @param {object} text - Note text
          * @returns {Promise}
          */
-        create: utils.requestWithDataFun('POST', '/annotations/', [], dataHeaders.annotation, true),
+        create: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/annotations',
+            headers: dataHeaders.annotation,
+            followLocation: true
+        }),
 
          /**
          * Delete a single annotation
@@ -55,7 +76,13 @@ module.exports = function annotations() {
          * @param {string} id - Annotation UUID
          * @returns {Promise}
          */
-        delete: utils.requestFun('DELETE', '/annotations/{id}', ['id']),
+        delete: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'DELETE',
+            resource: '/annotations/{id}',
+            args: ['id']
+        }),
 
         /**
          * Get a list of annotations
@@ -64,7 +91,12 @@ module.exports = function annotations() {
          * @memberof api.annotations
          * @returns {promise}
          */
-        list: utils.requestFun('GET', '/annotations/'),
+        list: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/annotations'
+        }),
 
         /**
          * The total number of annotations - set after the first call to annotations.list()
@@ -82,7 +114,11 @@ module.exports = function annotations() {
          * @memberof api.annotations
          * @returns {promise}
          */
-        nextPage: utils.requestPageFun('next'),
+        nextPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'next'
+        }),
 
         /**
          * Get the previous page of annotations
@@ -91,7 +127,11 @@ module.exports = function annotations() {
          * @memberof api.annotations
          * @returns {promise}
          */
-        previousPage: utils.requestPageFun('previous'),
+        previousPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'previous'
+        }),
 
         /**
          * Get the last page of annotations
@@ -100,7 +140,11 @@ module.exports = function annotations() {
          * @memberof api.annotations
          * @returns {promise}
          */
-        lastPage: utils.requestPageFun('last'),
+        lastPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'last'
+        }),
 
         /**
          * Get pagination links

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.catalog
  */
-module.exports = function catalog() {
+module.exports = function catalog(options) {
     return {
 
         /**
@@ -19,7 +19,12 @@ module.exports = function catalog() {
          * @param {object} params - A catalog search filter
          * @returns {promise}
          */
-        search: utils.requestFun('GET', '/catalog'),
+        search: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/catalog'
+        }),
 
         /**
          * Retrieve a document data from catalog
@@ -30,7 +35,13 @@ module.exports = function catalog() {
          * @param {object} params - A catalog search filter
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/catalog/{id}', ['id'])
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/catalog/{id}',
+            args: ['id']
+        })
 
     };
 };

--- a/lib/api/documents.js
+++ b/lib/api/documents.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.documents
  */
-module.exports = function documents() {
+module.exports = function documents(options) {
     var dataHeaders = {
             'Content-Type': 'application/vnd.mendeley-document.1+json'
         },
@@ -16,8 +16,19 @@ module.exports = function documents() {
             'Content-Type': 'application/vnd.mendeley-document-clone.1+json'
         },
 
-        listDocuments = utils.requestFun('GET', '/documents/'),
-        listFolder = utils.requestFun('GET', '/folders/{id}/documents', ['id']);
+        listDocuments = utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/documents'
+        }),
+        listFolder = utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/folders/{id}/documents',
+            args: ['id']
+        });
 
     return {
 
@@ -29,7 +40,14 @@ module.exports = function documents() {
          * @param {object} data - The document data
          * @returns {promise}
          */
-        create: utils.requestWithDataFun('POST', '/documents', false, dataHeaders, true),
+        create: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/documents',
+            headers: dataHeaders,
+            followLocation: true
+        }),
 
         /**
          * Create a new document from a file
@@ -39,7 +57,12 @@ module.exports = function documents() {
          * @param {object} file - A file object
          * @returns {promise}
          */
-        createFromFile: utils.requestWithFileFun('POST', '/documents'),
+        createFromFile: utils.requestWithFileFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/documents'
+        }),
 
         /**
          * Create a new group document from a file
@@ -50,7 +73,13 @@ module.exports = function documents() {
          * @param {string} groupId - A group UUID
          * @returns {promise}
          */
-        createFromFileInGroup: utils.requestWithFileFun('POST', '/documents', 'group'),
+        createFromFileInGroup: utils.requestWithFileFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/documents',
+            linkType: 'group'
+        }),
 
         /**
          * Retrieve a document
@@ -60,7 +89,13 @@ module.exports = function documents() {
          * @param {string} id - A document UUID
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/documents/{id}', ['id']),
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/documents/{id}',
+            args: ['id']
+        }),
 
         /**
          * Update document
@@ -71,7 +106,15 @@ module.exports = function documents() {
          * @param {object} data - The new document data
          * @returns {promise}
          */
-        update: utils.requestWithDataFun('PATCH', '/documents/{id}', ['id'], dataHeaders, true),
+        update: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'PATCH',
+            resource: '/documents/{id}',
+            args: ['id'],
+            headers: dataHeaders,
+            followLocation: true
+        }),
 
         /**
          * Clone a document from user library to a group ( or vice versa )
@@ -81,7 +124,15 @@ module.exports = function documents() {
          * @param {string} id - A document UUID
          * @returns {promise}
          */
-        clone: utils.requestWithDataFun('POST', '/documents/{id}/actions/cloneTo', ['id'], cloneDataHeaders, true),
+        clone: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/documents/{id}/actions/cloneTo',
+            args: ['id'],
+            headers: cloneDataHeaders,
+            followLocation: true
+        }),
 
         /**
          * List documents
@@ -112,7 +163,12 @@ module.exports = function documents() {
          * @param {object} params - Search paramaters
          * @returns {promise}
          */
-        search: utils.requestFun('GET', '/search/documents'),
+        search: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/search/documents'
+        }),
 
         /**
          * Move a document to the trash
@@ -122,7 +178,14 @@ module.exports = function documents() {
          * @param {string} id - A document UUID
          * @returns {promise}
          */
-        trash: utils.requestFun('POST', '/documents/{id}/trash', ['id'], dataHeaders),
+        trash: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/documents/{id}/trash',
+            args: ['id'],
+            headers: dataHeaders
+        }),
 
         /**
          * The total number of documents - set after the first call to documents.list()
@@ -140,7 +203,11 @@ module.exports = function documents() {
          * @memberof api.documents
          * @returns {promise}
          */
-        nextPage: utils.requestPageFun('next'),
+        nextPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'next'
+        }),
 
         /**
          * Get the previous page of documents
@@ -149,7 +216,11 @@ module.exports = function documents() {
          * @memberof api.documents
          * @returns {promise}
          */
-        previousPage: utils.requestPageFun('previous'),
+        previousPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'previous'
+        }),
 
         /**
          * Get the last page of documents
@@ -158,7 +229,11 @@ module.exports = function documents() {
          * @memberof api.documents
          * @returns {promise}
          */
-        lastPage: utils.requestPageFun('last'),
+        lastPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'last'
+        }),
 
         /**
          * Get pagination links

--- a/lib/api/files.js
+++ b/lib/api/files.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.files
  */
-module.exports = function files() {
+module.exports = function files(options) {
     var headers   = { 'Accept': 'application/vnd.mendeley-file.1+json' };
 
     return {
@@ -23,7 +23,14 @@ module.exports = function files() {
          * @param {function} progressHandler - Function called every time a progress event occurs
          * @returns {promise}
          */
-        create: utils.requestWithFileFun('POST', '/files', 'document', headers),
+        create: utils.requestWithFileFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/files',
+            headers: headers,
+            linkType: 'document'
+        }),
 
         /**
          * Get a list of files for a document
@@ -33,7 +40,14 @@ module.exports = function files() {
          * @param {string} id - A document UUID
          * @returns {promise}
          */
-        list: utils.requestFun('GET', '/files?document_id={id}', ['id'], headers),
+        list: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/files?document_id={id}',
+            args: ['id'],
+            headers: headers
+        }),
 
         /**
          * Delete a file
@@ -43,7 +57,13 @@ module.exports = function files() {
          * @param {string} id - A file UUID
          * @returns {promise}
          */
-        remove: utils.requestFun('DELETE', '/files/{id}', ['id'])
+        remove: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'DELETE',
+            resource: '/files/{id}',
+            args: ['id']
+        })
 
     };
 };

--- a/lib/api/folders.js
+++ b/lib/api/folders.js
@@ -7,7 +7,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.folders
  */
-module.exports = function folders() {
+module.exports = function folders(options) {
     var dataHeaders = {
             folder: { 'Content-Type': 'application/vnd.mendeley-folder.1+json' },
             'document': { 'Content-Type': 'application/vnd.mendeley-document.1+json' }
@@ -23,7 +23,14 @@ module.exports = function folders() {
          * @param {object} data - The folder data
          * @returns {promise}
          */
-        create: utils.requestWithDataFun('POST', '/folders', [], dataHeaders.folder, true),
+        create: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/folders',
+            headers: dataHeaders.folder,
+            followLocation: true
+        }),
 
         /**
          * Retrieve a folder
@@ -33,7 +40,13 @@ module.exports = function folders() {
          * @param {string} id - A folder UUID
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/folders/{id}', ['id']),
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/folders/{id}',
+            args: ['id']
+        }),
 
         /**
          * Update a folder
@@ -44,7 +57,15 @@ module.exports = function folders() {
          * @param {object} data - The folder data
          * @returns {promise}
          */
-        update: utils.requestWithDataFun('PATCH', '/folders/{id}', ['id'], dataHeaders.folder, true),
+        update: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'PATCH',
+            resource: '/folders/{id}',
+            args: ['id'],
+            headers: dataHeaders.folder,
+            followLocation: true
+        }),
 
         /**
          * Delete a folder
@@ -54,7 +75,13 @@ module.exports = function folders() {
          * @param {string} id - A folder UUID
          * @returns {promise}
          */
-        delete: utils.requestFun('DELETE', '/folders/{id}', ['id']),
+        delete: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'DELETE',
+            resource: '/folders/{id}',
+            args: ['id']
+        }),
 
         /**
          * Remove a document from a folder
@@ -65,7 +92,14 @@ module.exports = function folders() {
          * @param {string} documentId - A document UUID
          * @returns {promise}
          */
-        removeDocument: utils.requestFun('DELETE', '/folders/{id}/documents/{docId}', ['id', 'docId'], dataHeaders.folder),
+        removeDocument: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'DELETE',
+            resource: '/folders/{id}/documents/{docId}',
+            args: ['id', 'docId'],
+            headers: dataHeaders.folder
+        }),
 
         /**
          * Add a document to a folder
@@ -75,7 +109,14 @@ module.exports = function folders() {
          * @param {string} id - A folder UUID
          * @returns {promise}
          */
-        addDocument: utils.requestWithDataFun('POST', '/folders/{id}/documents', ['id'], dataHeaders.document, false),
+        addDocument: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/folders/{id}/documents',
+            args: ['id'],
+            headers: dataHeaders.document
+        }),
 
         /**
          * Get a list of folders
@@ -84,7 +125,12 @@ module.exports = function folders() {
          * @memberof api.folders
          * @returns {promise}
          */
-        list: utils.requestFun('GET', '/folders/'),
+        list: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/folders'
+        }),
 
         /**
          * The total number of folders - set after the first call to folders.list()
@@ -102,7 +148,11 @@ module.exports = function folders() {
          * @memberof api.folders
          * @returns {promise}
          */
-        nextPage: utils.requestPageFun('next'),
+        nextPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'next'
+        }),
 
         /**
          * Get the previous page of folders
@@ -111,7 +161,11 @@ module.exports = function folders() {
          * @memberof api.folders
          * @returns {promise}
          */
-        previousPage: utils.requestPageFun('previous'),
+        previousPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'previous'
+        }),
 
         /**
          * Get the last page of folders
@@ -120,7 +174,11 @@ module.exports = function folders() {
          * @memberof api.folders
          * @returns {promise}
          */
-        lastPage: utils.requestPageFun('last'),
+        lastPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'last'
+        }),
 
         /**
          * Get pagination links

--- a/lib/api/followers.js
+++ b/lib/api/followers.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.followers
  */
-module.exports = function followers() {
+module.exports = function followers(options) {
     var dataHeaders = {
         create: {
             'Content-Type': 'application/vnd.mendeley-follow-request.1+json'
@@ -33,7 +33,12 @@ module.exports = function followers() {
          * }
          * @returns {promise}
          */
-        list: utils.requestFun('GET', '/followers'),
+        list: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/followers'
+        }),
 
         /**
          * Create a follower relationship.
@@ -48,7 +53,13 @@ module.exports = function followers() {
          * @param {object} data - { followed: <profile id> }
          * @returns {promise}
          */
-        create: utils.requestWithDataFun('POST', '/followers', false, dataHeaders.create, false),
+        create: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/followers',
+            headers: dataHeaders.create
+        }),
 
         /**
          * Delete a follower relationship.
@@ -59,7 +70,13 @@ module.exports = function followers() {
          * @memberof api.followers
          * @returns {promise}
          */
-        remove: utils.requestFun('DELETE', '/followers/{id}', ['id']),
+        remove: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'DELETE',
+            resource: '/followers/{id}',
+            args: ['id']
+        }),
 
         /**
          * Accept a follower request by updating the relationship.
@@ -72,7 +89,14 @@ module.exports = function followers() {
          * @param {object} data - { status: "following" } (note "following" is currently the only supported status)
          * @returns {promise}
          */
-        accept: utils.requestWithDataFun('PATCH', '/followers/{id}', ['id'], dataHeaders.accept, false)
+        accept: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'PATCH',
+            resource: '/followers/{id}',
+            args: ['id'],
+            headers: dataHeaders.accept
+        })
 
     };
 };

--- a/lib/api/groups.js
+++ b/lib/api/groups.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.groups
  */
-module.exports = function groups() {
+module.exports = function groups(options) {
     return {
 
         /**
@@ -19,7 +19,13 @@ module.exports = function groups() {
          * @param {string} id - A group UUID
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/groups/{id}', ['id']),
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/groups/{id}',
+            args: ['id']
+        }),
 
         /**
          * Get a list of groups
@@ -28,7 +34,12 @@ module.exports = function groups() {
          * @memberof api.groups
          * @returns {promise}
          */
-        list: utils.requestFun('GET', '/groups/'),
+        list: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/groups'
+        }),
 
         /**
          * The total number of groups - set after the first call to groups.list()
@@ -46,7 +57,11 @@ module.exports = function groups() {
          * @memberof api.groups
          * @returns {promise}
          */
-        nextPage: utils.requestPageFun('next'),
+        nextPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'next'
+        }),
 
         /**
          * Get the previous page of groups
@@ -55,7 +70,11 @@ module.exports = function groups() {
          * @memberof api.groups
          * @returns {promise}
          */
-        previousPage: utils.requestPageFun('previous'),
+        previousPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'previous'
+        }),
 
         /**
          * Get the last page of groups
@@ -64,7 +83,11 @@ module.exports = function groups() {
          * @memberof api.groups
          * @returns {promise}
          */
-        lastPage: utils.requestPageFun('last'),
+        lastPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'last'
+        }),
 
         /**
          * Get pagination links

--- a/lib/api/institution-trees.js
+++ b/lib/api/institution-trees.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.institutionTrees
  */
-module.exports = function institutionTrees() {
+module.exports = function institutionTrees(options) {
     return {
 
         /**
@@ -19,7 +19,12 @@ module.exports = function institutionTrees() {
          * @param {object} params - An institution ID
          * @returns {promise}
          */
-        list: utils.requestFun('GET', '/institution_trees'),
+        list: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/institution_trees'
+        }),
 
         /**
          * Return only the child nodes of a given institution
@@ -29,7 +34,13 @@ module.exports = function institutionTrees() {
          * @param {string} id - An institution ID
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/institution_trees/{id}', ['id'])
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/institution_trees/{id}',
+            args: ['id']
+        })
 
     };
 };

--- a/lib/api/institutions.js
+++ b/lib/api/institutions.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.institutions
  */
-module.exports = function institutions() {
+module.exports = function institutions(options) {
     return {
 
         /**
@@ -19,7 +19,12 @@ module.exports = function institutions() {
          * @param {object} params - An institutions search filter
          * @returns {promise}
          */
-        search: utils.requestFun('GET', '/institutions'),
+        search: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/institutions'
+        }),
 
         /**
          * Retrieve an institution object
@@ -29,7 +34,13 @@ module.exports = function institutions() {
          * @param {string} id - An institution ID
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/institutions/{id}', ['id'])
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/institutions/{id}',
+            args: ['id']
+        })
 
     };
 };

--- a/lib/api/locations.js
+++ b/lib/api/locations.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.locations
  */
-module.exports = function locations() {
+module.exports = function locations(options) {
     return {
 
         /**
@@ -19,7 +19,12 @@ module.exports = function locations() {
          * @param {object} params - A locations search filter
          * @returns {promise}
          */
-        search: utils.requestFun('GET', '/locations'),
+        search: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/locations'
+        }),
 
         /**
          * Retrieve a location object
@@ -29,7 +34,13 @@ module.exports = function locations() {
          * @param {string} id - A location ID
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/locations/{id}', ['id'])
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/locations/{id}',
+            args: ['id']
+        })
 
     };
 };

--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.metadata
  */
-module.exports = function metadata() {
+module.exports = function metadata(options) {
     var dataHeaders = {
             'Accept': 'application/vnd.mendeley-document-lookup.1+json'
         };
@@ -23,7 +23,13 @@ module.exports = function metadata() {
          * @param {object} params - A metadata search filter
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/metadata', false, dataHeaders, false)
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/metadata',
+            headers: dataHeaders
+        })
 
     };
 };

--- a/lib/api/profiles.js
+++ b/lib/api/profiles.js
@@ -5,7 +5,7 @@ var utils = require('../utilities');
 var MIME_TYPES = {
   PROFILE: 'application/vnd.mendeley-profiles.1+json',
   PROFILE_UPDATE: 'application/vnd.mendeley-profile-amendment.1+json'
-}
+};
 
 /**
  * Profiles API

--- a/lib/api/profiles.js
+++ b/lib/api/profiles.js
@@ -76,7 +76,23 @@ module.exports = function profiles(options) {
              method: 'GET',
              resource: '/profiles?email={email}',
              args: ['email']
-         })
+         }),
+
+         /**
+          * Retrieve a profile by link
+          *
+          * @method
+          * @memberof api.profiles
+          * @param {string} link - Short name
+          * @returns {promise}
+          */
+          retrieveByLink: utils.requestFun({
+              authFlow: options.authFlow,
+              baseUrl: options.baseUrl,
+              method: 'GET',
+              resource: '/profiles?link={link}',
+              args: ['link']
+          })
 
     };
 };

--- a/lib/api/profiles.js
+++ b/lib/api/profiles.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.profiles
  */
-module.exports = function profiles() {
+module.exports = function profiles(options) {
     var dataHeaders = {
         'Content-Type': 'application/vnd.mendeley-profile-amendment.1+json'
     };
@@ -22,7 +22,12 @@ module.exports = function profiles() {
          * @memberof api.profiles
          * @returns {promise}
          */
-        me: utils.requestFun('GET', '/profiles/me'),
+        me: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/profiles/me'
+        }),
 
         /**
          * Retrieve a profile by id
@@ -32,7 +37,13 @@ module.exports = function profiles() {
          * @param {string} id - User id
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/profiles/{id}', ['id']),
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/profiles/{id}',
+            args: ['id']
+        }),
 
         /**
          * Update profiles
@@ -42,8 +53,15 @@ module.exports = function profiles() {
          * @param {object} data - The new profiles data
          * @returns {promise}
          */
-        update: utils.requestWithDataFun('PATCH', '/profiles/me', [], dataHeaders, true),
-        
+        update: utils.requestWithDataFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'PATCH',
+            resource: '/profiles/me',
+            headers: dataHeaders,
+            followLocation: true
+        }),
+
         /**
          * Retrieve a profile by email address
          *
@@ -52,7 +70,13 @@ module.exports = function profiles() {
          * @param {string} email - Email address
          * @returns {promise}
          */
-         retrieveByEmail: utils.requestFun('GET', '/profiles?email={email}', ['email'])
+         retrieveByEmail: utils.requestFun({
+             authFlow: options.authFlow,
+             baseUrl: options.baseUrl,
+             method: 'GET',
+             resource: '/profiles?email={email}',
+             args: ['email']
+         })
 
     };
 };

--- a/lib/api/profiles.js
+++ b/lib/api/profiles.js
@@ -2,6 +2,11 @@
 
 var utils = require('../utilities');
 
+var MIME_TYPES = {
+  PROFILE: 'application/vnd.mendeley-profiles.1+json',
+  PROFILE_UPDATE: 'application/vnd.mendeley-profile-amendment.1+json'
+}
+
 /**
  * Profiles API
  *
@@ -9,10 +14,6 @@ var utils = require('../utilities');
  * @name api.profiles
  */
 module.exports = function profiles(options) {
-    var dataHeaders = {
-        'Content-Type': 'application/vnd.mendeley-profile-amendment.1+json'
-    };
-
     return {
 
         /**
@@ -26,7 +27,10 @@ module.exports = function profiles(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/profiles/me'
+            resource: '/profiles/me',
+            headers: {
+              Accept: MIME_TYPES.PROFILE
+            }
         }),
 
         /**
@@ -42,7 +46,10 @@ module.exports = function profiles(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/profiles/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              Accept: MIME_TYPES.PROFILE
+            }
         }),
 
         /**
@@ -58,7 +65,10 @@ module.exports = function profiles(options) {
             baseUrl: options.baseUrl,
             method: 'PATCH',
             resource: '/profiles/me',
-            headers: dataHeaders,
+            headers: {
+              'Content-Type': MIME_TYPES.PROFILE_UPDATE,
+              Accept: MIME_TYPES.PROFILE
+            },
             followLocation: true
         }),
 
@@ -75,7 +85,10 @@ module.exports = function profiles(options) {
              baseUrl: options.baseUrl,
              method: 'GET',
              resource: '/profiles?email={email}',
-             args: ['email']
+             args: ['email'],
+             headers: {
+               Accept: MIME_TYPES.PROFILE
+             }
          }),
 
          /**
@@ -91,7 +104,10 @@ module.exports = function profiles(options) {
               baseUrl: options.baseUrl,
               method: 'GET',
               resource: '/profiles?link={link}',
-              args: ['link']
+              args: ['link'],
+              headers: {
+                Accept: MIME_TYPES.PROFILE
+              }
           })
 
     };

--- a/lib/api/trash.js
+++ b/lib/api/trash.js
@@ -8,7 +8,7 @@ var utils = require('../utilities');
  * @namespace
  * @name api.trash
  */
-module.exports = function trash() {
+module.exports = function trash(options) {
     return {
 
         /**
@@ -19,7 +19,13 @@ module.exports = function trash() {
          * @param {string} id - A document UUID
          * @returns {promise}
          */
-        retrieve: utils.requestFun('GET', '/trash/{id}', ['id']),
+        retrieve: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/trash/{id}',
+            args: ['id']
+        }),
 
         /**
          * List all documents in the trash
@@ -28,7 +34,12 @@ module.exports = function trash() {
          * @memberof api.trash
          * @returns {promise}
          */
-        list: utils.requestFun('GET', '/trash/'),
+        list: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/trash'
+        }),
 
         /**
          * Restore a trashed document
@@ -38,7 +49,13 @@ module.exports = function trash() {
          * @param {string} id - A document UUID
          * @returns {promise}
          */
-        restore: utils.requestFun('POST', '/trash/{id}/restore', ['id']),
+        restore: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'POST',
+            resource: '/trash/{id}/restore',
+            args: ['id']
+        }),
 
         /**
          * Permanently delete a trashed document
@@ -48,7 +65,13 @@ module.exports = function trash() {
          * @param {string} id - A document UUID
          * @returns {promise}
          */
-        destroy: utils.requestFun('DELETE', '/trash/{id}', ['id']),
+        destroy: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'DELETE',
+            resource: '/trash/{id}',
+            args: ['id']
+        }),
 
         /**
          * The total number of trashed documents - set after the first call to trash.list()
@@ -66,7 +89,11 @@ module.exports = function trash() {
          * @memberof api.trash
          * @returns {promise}
          */
-        nextPage: utils.requestPageFun('next'),
+        nextPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'next'
+        }),
 
         /**
          * Get the previous page of trash
@@ -75,7 +102,11 @@ module.exports = function trash() {
          * @memberof api.trash
          * @returns {promise}
          */
-        previousPage: utils.requestPageFun('previous'),
+        previousPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'previous'
+        }),
 
         /**
          * Get the last page of trash
@@ -84,7 +115,11 @@ module.exports = function trash() {
          * @memberof api.trash
          * @returns {promise}
          */
-        lastPage: utils.requestPageFun('last'),
+        lastPage: utils.requestPageFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            rel: 'last'
+        }),
 
 
         /**

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,6 +3,7 @@
 var assign = require('object-assign');
 var axios = require('axios');
 var Bluebird = require('bluebird');
+var formUrlEncoded = require('form-urlencoded');
 
 var defaults = {
     win: window,
@@ -22,12 +23,11 @@ var defaultsAuthCodeFlow = {
     refreshAccessTokenUrl: false
 };
 
-var settings = {};
-
 module.exports = {
     implicitGrantFlow: implicitGrantFlow,
     authCodeFlow: authCodeFlow,
-    authenticatedFlow: authenticatedFlow
+    authenticatedFlow: authenticatedFlow,
+    clientCredentialsFlow: clientCredentialsFlow
 };
 
 function authenticatedFlow(token) {
@@ -42,7 +42,7 @@ function authenticatedFlow(token) {
 
 function implicitGrantFlow(options) {
 
-    settings = assign({}, defaults, defaultsImplicitFlow, options || {});
+    var settings = assign({}, defaults, defaultsImplicitFlow, options || {});
 
     if (!settings.clientId) {
         console.error('You must provide a clientId for implicit grant flow');
@@ -61,56 +61,98 @@ function implicitGrantFlow(options) {
         '&scope=' + settings.scope +
         '&response_type=token';
 
-    if (settings.authenticateOnStart && !getAccessTokenCookieOrUrl()) {
-        authenticate();
+    if (settings.authenticateOnStart && !getAccessTokenCookieOrUrl(settings)) {
+        authenticate(settings);
     }
 
     return {
-        authenticate: authenticate,
-        getToken: getAccessTokenCookieOrUrl,
+        authenticate: authenticate.bind(null, settings),
+        getToken: getAccessTokenCookieOrUrl.bind(null, settings),
         refreshToken: noop()
     };
 }
 
 function authCodeFlow(options) {
 
-    settings = assign({}, defaults, defaultsAuthCodeFlow, options || {});
+    var settings = assign({}, defaults, defaultsAuthCodeFlow, options || {});
 
     if (!settings.apiAuthenticateUrl) {
         console.error('You must provide an apiAuthenticateUrl for auth code flow');
         return false;
     }
 
-    if (settings.authenticateOnStart && !getAccessTokenCookie()) {
-        authenticate();
+    if (settings.authenticateOnStart && !getAccessTokenCookie(settings)) {
+        authenticate(settings);
     }
 
     return {
-        authenticate: authenticate,
-        getToken: getAccessTokenCookie,
-        refreshToken: refreshAccessTokenCookie
+        authenticate: authenticate.bind(null, settings),
+        getToken: getAccessTokenCookie.bind(null, settings),
+        refreshToken: refreshAccessTokenCookie.bind(null, settings)
     };
+}
+
+function clientCredentialsFlow(options) {
+  var settings = assign({}, {
+    tokenUrl: 'https://api.mendeley.com/oauth/token',
+    clientId: null,
+    clientSecret: null,
+    redirectUri: null,
+    scope: 'all'
+  }, options || {});
+
+  if (!settings.clientId) {
+      throw new Error('You must provide a clientId for client credentials code flow');
+  }
+
+  if (!settings.clientSecret) {
+      throw new Error('You must provide a clientSecret for client credentials code flow');
+  }
+
+  if (!settings.redirectUri) {
+      throw new Error('You must provide a redirectUri for client credentials code flow');
+  }
+
+  return {
+      authenticate: noop(),
+      getToken: function () {
+        return settings.accessToken;
+      },
+      refreshToken: function () {
+        return axios.post(settings.tokenUrl, formUrlEncoded({
+          'grant_type': 'client_credentials',
+          'client_id': settings.clientId,
+          'client_secret': settings.clientSecret,
+          'redirect_uri': settings.redirectUri,
+          'scope': settings.scope
+        }))
+        .then(function (result) {
+          /*jshint camelcase: false */
+          settings.accessToken = result.data.access_token;
+        });
+      }
+  };
 }
 
 function noop() {
     return function() { return false; };
 }
 
-function authenticate() {
+function authenticate(settings) {
     var url = typeof settings.apiAuthenticateUrl === 'function' ?
         settings.apiAuthenticateUrl() : settings.apiAuthenticateUrl;
 
-    clearAccessTokenCookie();
+    clearAccessTokenCookie(settings);
     settings.win.location = url;
 }
 
-function getAccessTokenCookieOrUrl() {
+function getAccessTokenCookieOrUrl(settings) {
     var location = settings.win.location,
         hash = location.hash ? location.hash.split('=')[1] : '',
-        cookie = getAccessTokenCookie();
+        cookie = getAccessTokenCookie(settings);
 
     if (hash && !cookie) {
-        setAccessTokenCookie(hash);
+        setAccessTokenCookie(settings, hash);
         return hash;
     }
     if (!hash && cookie) {
@@ -118,7 +160,7 @@ function getAccessTokenCookieOrUrl() {
     }
     if (hash && cookie) {
         if (hash !== cookie) {
-            setAccessTokenCookie(hash);
+            setAccessTokenCookie(settings, hash);
             return hash;
         }
         return cookie;
@@ -127,7 +169,7 @@ function getAccessTokenCookieOrUrl() {
     return '';
 }
 
-function getAccessTokenCookie() {
+function getAccessTokenCookie(settings) {
     var name = settings.accessTokenCookieName + '=',
         ca = settings.win.document.cookie.split(';');
 
@@ -146,18 +188,18 @@ function getAccessTokenCookie() {
     return '';
 }
 
-function setAccessTokenCookie(accessToken, expireHours) {
+function setAccessTokenCookie(settings, accessToken, expireHours) {
     var d = new Date();
     d.setTime(d.getTime() + ((expireHours || 1)*60*60*1000));
     var expires = 'expires=' + d.toUTCString();
     settings.win.document.cookie = settings.accessTokenCookieName + '=' + accessToken + '; ' + expires;
 }
 
-function clearAccessTokenCookie() {
-    setAccessTokenCookie('', -1);
+function clearAccessTokenCookie(settings) {
+    setAccessTokenCookie(settings, '', -1);
 }
 
-function refreshAccessTokenCookie() {
+function refreshAccessTokenCookie(settings) {
     if (settings.refreshAccessTokenUrl) {
         return new Bluebird(function(resolve, reject) {
             axios.get(settings.refreshAccessTokenUrl)

--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function decorateWithFor(originalInstance, factory, options) {
+    var instanceMap = {};
+
+    originalInstance.for = function (mappingKey) {
+        if (!mappingKey) {
+            return originalInstance;
+        }
+
+        if (!instanceMap[mappingKey]) {
+            // create a new instance
+            instanceMap[mappingKey] = factory(options);
+        }
+
+        return instanceMap[mappingKey];
+    };
+
+    return originalInstance;
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,10 +33,10 @@ module.exports = function (options) {
 
     Object.defineProperty(module.exports, 'API', {
       get: function () {
-        throw new Error('The .API property is deprecated, please see the documentation')
+        throw new Error('The .API property is deprecated, please see the documentation');
       },
       configurable: true
-    })
+    });
 
     return api(options);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,60 @@
 'use strict';
 
+var api = require('./api');
+var auth = require('./auth');
+var request = require('./request');
+
 // Exports Mendeley SDK
-module.exports = {
-    API: require('./api'),
-    Auth: require('./auth'),
-    Request: require('./request'),
+module.exports = function (options) {
+    if (!options) {
+      throw new Error('Please pass an options object with an authFlow property');
+    }
+
+    options.baseUrl = options.baseUrl || 'https://api.mendeley.com';
+    options.authFlow = options.authFlow || {};
+
+    if (typeof options.authFlow !== 'function') {
+        var authFlow = options.authFlow;
+
+        options.authFlow = function () {
+          return authFlow;
+        };
+    }
+
+    if (typeof options.baseUrl !== 'function') {
+        var baseUrl = options.baseUrl;
+
+        options.baseUrl = function () {
+          return baseUrl;
+        };
+    }
+
+    delete module.exports.API;
+
+    return api(options);
 };
+
+module.exports.Auth = auth;
+module.exports.Request = request;
+
+// this is to maintain backwards compatibility
+var authFlow = false;
+var baseUrl = 'https://api.mendeley.com';
+
+var defaultOptions = {
+    authFlow: function () {
+      return authFlow;
+    },
+    baseUrl: function () {
+      return baseUrl;
+    }
+};
+
+module.exports.API = api(defaultOptions);
+module.exports.API.setAuthFlow = function (flow) {
+  authFlow = flow;
+};
+module.exports.API.setBaseUrl = function (url) {
+  baseUrl = url;
+};
+// end backwards compatibility

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,13 @@ module.exports = function (options) {
 
     delete module.exports.API;
 
+    Object.defineProperty(module.exports, 'API', {
+      get: function () {
+        throw new Error('The .API property is deprecated, please see the documentation')
+      },
+      configurable: true
+    })
+
     return api(options);
 };
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -4,9 +4,6 @@ var Request = require('./request');
 var assign = require('object-assign');
 var Bluebird = require('bluebird');
 
-var baseUrl = 'https://api.mendeley.com';
-var authFlow = false;
-
 /**
  * Utilities
  *
@@ -14,9 +11,6 @@ var authFlow = false;
  * @name utilities
  */
 module.exports = {
-    setAuthFlow: setAuthFlow,
-    setBaseUrl: setBaseUrl,
-
     requestFun: requestFun,
     requestPageFun: requestPageFun,
     requestWithDataFun: requestWithDataFun,
@@ -25,16 +19,16 @@ module.exports = {
     resetPaginationLinks: resetPaginationLinks
 };
 
-function setAuthFlow(auth) {
-    authFlow = auth;
-}
-
-function setBaseUrl(url) {
-    baseUrl = url;
-}
-
 function dataFilter(response) {
     return response.data;
+}
+
+function normaliseOptions(options) {
+  options.responseFilter = options.responseFilter || dataFilter;
+  options.args = options.args || [];
+  options.headers = options.headers || {};
+
+  return options;
 }
 
 /**
@@ -48,41 +42,37 @@ function dataFilter(response) {
  * @param {array} headers
  * @returns {function}
  */
-function requestFun(responseFilter, method, uriTemplate, uriVars, headers) {
-    if (typeof responseFilter !== 'function') {
-        return requestFun(dataFilter, responseFilter, method, uriTemplate, uriVars);
-    }
-
-    uriVars = uriVars || [];
+function requestFun(options) {
+    options = normaliseOptions(options);
 
     return function() {
         var args = Array.prototype.slice.call(arguments, 0);
-        var url = getUrl(uriTemplate, uriVars, args);
-        var params = args[uriVars.length];
+        var url = getUrl(options, args);
+        var params = args[options.args.length];
 
         var request = {
-            method: method,
+            method: options.method,
             responseType: 'json',
             url: url,
-            headers: getRequestHeaders(headers),
+            headers: getRequestHeaders(options.headers),
             params: params
         };
 
         var settings = {
-            authFlow: authFlow
+            authFlow: options.authFlow()
         };
 
-        if (method === 'GET') {
+        if (options.method === 'GET') {
             settings.maxRetries = 1;
         }
 
         var promise = Request.create(request, settings).send();
-        
+
         return promise.then(function(response) {
             setPaginationLinks.call(this, response.headers);
 
             return response;
-        }.bind(this)).then(responseFilter);
+        }.bind(this)).then(options.responseFilter);
     };
 }
 
@@ -95,34 +85,32 @@ function requestFun(responseFilter, method, uriTemplate, uriVars, headers) {
  * @param {object} headers
  * @returns {function}
  */
-function requestPageFun(responseFilter, rel, headers) {
-    if (typeof responseFilter !== 'function') {
-        return requestPageFun(dataFilter, responseFilter, rel);
-    }
+function requestPageFun(options) {
+    options = normaliseOptions(options);
 
     return function() {
-        if (!this.paginationLinks[rel]) {
+        if (!this.paginationLinks[options.rel]) {
             return Bluebird.reject(new Error('No pagination links'));
         }
 
         var request = {
             method: 'GET',
             responseType: 'json',
-            url: this.paginationLinks[rel],
-            headers: getRequestHeaders(headers || {})
+            url: this.paginationLinks[options.rel],
+            headers: getRequestHeaders(options.headers)
         };
 
         var settings = {
-            authFlow: authFlow,
+            authFlow: options.authFlow(),
             maxRetries: 1
         };
 
         var promise = Request.create(request, settings).send();
-        
+
         return promise.then(function(response) {
             setPaginationLinks.call(this, response.headers);
             return response;
-        }.bind(this)).then(responseFilter);
+        }.bind(this)).then(options.responseFilter);
     };
 }
 
@@ -141,32 +129,28 @@ function requestPageFun(responseFilter, rel, headers) {
  * @param {bool} followLocation - follow the returned location header? Default is false
  * @returns {function}
  */
-function requestWithDataFun(responseFilter, method, uriTemplate, uriVars, headers, followLocation) {
-    if (typeof responseFilter !== 'function') {
-        return requestWithDataFun(dataFilter, responseFilter, method, uriTemplate, uriVars, headers);
-    }
-
-    uriVars = uriVars || [];
+function requestWithDataFun(options) {
+    options = normaliseOptions(options);
 
     return function() {
         var args = Array.prototype.slice.call(arguments, 0);
-        var url = getUrl(uriTemplate, uriVars, args);
-        var data = args[uriVars.length];
+        var url = getUrl(options, args);
+        var data = args[options.args.length];
         var request = {
-            method: method,
+            method: options.method,
             url: url,
-            headers: getRequestHeaders(headers, data),
+            headers: getRequestHeaders(options.headers, data),
             data: JSON.stringify(data)
         };
 
         var settings = {
-            authFlow: authFlow,
-            followLocation: followLocation
+            authFlow: options.authFlow(),
+            followLocation: options.followLocation
         };
 
         var promise = Request.create(request, settings).send();
 
-        return promise.then(responseFilter);
+        return promise.then(options.responseFilter);
     };
 }
 
@@ -181,17 +165,15 @@ function requestWithDataFun(responseFilter, method, uriTemplate, uriVars, header
  * @param {object} headers - Any additional headers to send
  * @returns {function}
  */
-function requestWithFileFun(responseFilter, method, uriTemplate, linkType, headers) {
-    if (typeof responseFilter !== 'function') {
-        return requestWithFileFun(dataFilter, responseFilter, method, uriTemplate, linkType);
-    }
+function requestWithFileFun(options) {
+    options = normaliseOptions(options);
 
     return function() {
         var args = Array.prototype.slice.call(arguments, 0);
-        var url = getUrl(uriTemplate, [], args);
+        var url = getUrl(options, args);
         var file = args[0];
         var linkId = args[1];
-        var requestHeaders = assign({}, getRequestHeaders(uploadHeaders(file, linkId, linkType), method), headers);
+        var requestHeaders = assign({}, getRequestHeaders(uploadHeaders(options, file, linkId), options.method), options.headers);
         var progressHandler;
 
         if (typeof args[args.length - 1] === 'function') {
@@ -199,7 +181,7 @@ function requestWithFileFun(responseFilter, method, uriTemplate, linkType, heade
         }
 
         var request = {
-            method: method,
+            method: options.method,
             url: url,
             headers: requestHeaders,
             data: file,
@@ -207,12 +189,12 @@ function requestWithFileFun(responseFilter, method, uriTemplate, linkType, heade
         };
 
         var settings = {
-            authFlow: authFlow
+            authFlow: options.authFlow()
         };
 
         var promise = Request.create(request, settings).send();
 
-        return promise.then(responseFilter);
+        return promise.then(options.responseFilter);
     };
 }
 
@@ -243,13 +225,15 @@ function encodeRFC5987ValueChars(str) {
  * @param {string} linkType either 'group' or 'document'
  * @returns {object}
  */
-function uploadHeaders(file, linkId, linkType) {
+function uploadHeaders(options, file, linkId) {
     var headers = {
         'Content-Type': !!file.type ? file.type : 'application/octet-stream',
         'Content-Disposition': 'attachment; filename*=UTF-8\'\'' + encodeRFC5987ValueChars(file.name)
     };
-    if (linkType && linkId) {
-        switch(linkType) {
+    if (options.linkType && linkId) {
+        var baseUrl = options.baseUrl(options.method, options.resource, options.headers);
+
+        switch(options.linkType) {
             case 'group':
                 headers.Link = '<' + baseUrl + '/groups/' + linkId +'>; rel="group"';
                 break;
@@ -271,16 +255,20 @@ function uploadHeaders(file, linkId, linkType) {
  * @param {array} uriValues
  * @returns {string}
  */
-function getUrl(uriTemplate, uriProps, uriValues) {
-    if (!uriProps.length) {
-        return baseUrl + uriTemplate;
+function getUrl(options, args) {
+    var baseUrl = options.baseUrl(options.method, options.resource, options.headers);
+
+    if (!options.args.length) {
+        return baseUrl + options.resource;
     }
+
     var uriParams = {};
-    uriProps.forEach(function(prop, i) {
-        uriParams[prop] = uriValues[i];
+
+    options.args.forEach(function(prop, index) {
+        uriParams[prop] = args[index];
     });
 
-    return baseUrl + expandUriTemplate(uriTemplate, uriParams);
+    return baseUrl + expandUriTemplate(options.resource, uriParams);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "axios": "^0.12.0",
     "bluebird": "^3.4.0",
+    "form-urlencoded": "^1.4.1",
     "object-assign": "^4.1.0"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/jshint --config .jshintrc lib/*.js lib/api/*.js test/mocks/*.js test/spec/**/*.js",
     "test": "npm run lint && node_modules/.bin/serial-jasmine test/spec/**/*.spec.js test/spec/*.spec.js && node_modules/karma/bin/karma start --single-run",
+    "test:coverage": "nyc --reporter=html --all serial-jasmine test/spec/**/*.spec.js test/spec/*.spec.js",
     "start": "node examples/app.js",
     "build-jsdoc": "node_modules/.bin/jsdoc -d docs/ lib/*.js lib/*/*.js",
     "build-dist": "./node_modules/.bin/webpack && ./node_modules/.bin/webpack --minify",
@@ -43,6 +44,7 @@
     "karma-safari-launcher": "^0.1.1",
     "karma-webpack": "^1.7.0",
     "mversion": "^1.3.0",
+    "nyc": "^7.1.0",
     "serial-jasmine": "^0.1.1",
     "simple-oauth2": "^0.2.0",
     "webpack": "^1.8.5"
@@ -51,5 +53,15 @@
     "axios": "^0.12.0",
     "bluebird": "^3.4.0",
     "object-assign": "^4.1.0"
+  },
+  "nyc": {
+    "exclude": [
+      "coverage",
+      "dist",
+      "examples",
+      "test",
+      "karma.conf.js",
+      "webpack.config.js"
+    ]
   }
 }

--- a/test/spec/api.spec.js
+++ b/test/spec/api.spec.js
@@ -46,7 +46,7 @@ describe('api endpoints', function() {
       var sdk = require('../../');
 
       it('should remove the global api when using instances', function() {
-          var api = sdk({})
+          var api = sdk({});
 
           expect(api.API).toBeUndefined();
       });
@@ -57,8 +57,8 @@ describe('api endpoints', function() {
           var options = {
             baseUrl: baseUrl,
             authFlow: authFlow
-          }
-          var api = sdk(options)
+          };
+          var api = sdk(options);
 
           expect(options.baseUrl).toEqual(jasmine.any(Function));
           expect(options.baseUrl()).toEqual(baseUrl);
@@ -78,8 +78,8 @@ describe('api endpoints', function() {
           var options = {
             baseUrl: baseUrlFunc,
             authFlow: authFlowFunc
-          }
-          var api = sdk(options)
+          };
+          var api = sdk(options);
 
           expect(options.baseUrl).toEqual(baseUrlFunc);
           expect(options.baseUrl()).toEqual(baseUrl);
@@ -96,13 +96,13 @@ describe('api endpoints', function() {
       it('should allow two sets of authFlow credentials', function() {
           var options1 = {
             authFlow: 'authFlow1'
-          }
+          };
           var options2 = {
             authFlow: 'authFlow2'
-          }
+          };
 
-          var api1 = sdk(options1)
-          var api2 = sdk(options2)
+          var api1 = sdk(options1);
+          var api2 = sdk(options2);
 
           expect(options1.authFlow()).toEqual('authFlow1');
           expect(options2.authFlow()).toEqual('authFlow2');

--- a/test/spec/api.spec.js
+++ b/test/spec/api.spec.js
@@ -3,7 +3,7 @@
 
 describe('api endpoints', function() {
 
-    var api = require('../../lib/api');
+    var api = require('../../').API;
 
     it('are able to clone their instances', function() {
         Object.keys(api).map(function(endpointName) {
@@ -41,6 +41,73 @@ describe('api endpoints', function() {
         });
 
     });
+
+    describe('multiple instances', function() {
+      var sdk = require('../../');
+
+      it('should remove the global api when using instances', function() {
+          var api = sdk({})
+
+          expect(api.API).toBeUndefined();
+      });
+
+      it('should turn baseUrl and authFlow into functions', function() {
+          var baseUrl = 'baseUrl';
+          var authFlow = 'authFlow';
+          var options = {
+            baseUrl: baseUrl,
+            authFlow: authFlow
+          }
+          var api = sdk(options)
+
+          expect(options.baseUrl).toEqual(jasmine.any(Function));
+          expect(options.baseUrl()).toEqual(baseUrl);
+          expect(options.authFlow).toEqual(jasmine.any(Function));
+          expect(options.authFlow()).toEqual(authFlow);
+      });
+
+      it('should respect baseUrl and authFlow as functions', function() {
+          var baseUrl = 'baseUrl';
+          var baseUrlFunc = function () {
+            return baseUrl;
+          };
+          var authFlow = 'authFlow';
+          var authFlowFunc = function () {
+            return authFlow;
+          };
+          var options = {
+            baseUrl: baseUrlFunc,
+            authFlow: authFlowFunc
+          }
+          var api = sdk(options)
+
+          expect(options.baseUrl).toEqual(baseUrlFunc);
+          expect(options.baseUrl()).toEqual(baseUrl);
+          expect(options.authFlow).toEqual(authFlowFunc);
+          expect(options.authFlow()).toEqual(authFlow);
+      });
+
+      it('should explode if passed no options', function() {
+          expect(function () {
+            sdk();
+          }).toThrow();
+      });
+
+      it('should allow two sets of authFlow credentials', function() {
+          var options1 = {
+            authFlow: 'authFlow1'
+          }
+          var options2 = {
+            authFlow: 'authFlow2'
+          }
+
+          var api1 = sdk(options1)
+          var api2 = sdk(options2)
+
+          expect(options1.authFlow()).toEqual('authFlow1');
+          expect(options2.authFlow()).toEqual('authFlow2');
+      });
+    })
 
 });
 /* jshint sub: false */

--- a/test/spec/api.spec.js
+++ b/test/spec/api.spec.js
@@ -45,10 +45,12 @@ describe('api endpoints', function() {
     describe('multiple instances', function() {
       var sdk = require('../../');
 
-      it('should remove the global api when using instances', function() {
+      it('should object strenuously when accessing the global api and using instances', function() {
           var api = sdk({});
 
-          expect(api.API).toBeUndefined();
+          expect(function () {
+              sdk.API.toString()
+          }).toThrow();
       });
 
       it('should turn baseUrl and authFlow into functions', function() {

--- a/test/spec/api/annotations.spec.js
+++ b/test/spec/api/annotations.spec.js
@@ -6,7 +6,7 @@ var Bluebird = require('bluebird');
 
 describe('annotations api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var annotationsApi = api.annotations;
     var baseUrl = 'https://api.mendeley.com';
 
@@ -36,8 +36,8 @@ describe('annotations api', function() {
             expect(ajaxRequest.method).toBe('get');
         });
 
-        it('should use endpoint /annotations/', function() {
-            expect(ajaxRequest.url).toBe(baseUrl + '/annotations/');
+        it('should use endpoint /annotations', function() {
+            expect(ajaxRequest.url).toBe(baseUrl + '/annotations');
         });
 
         it('should NOT have a Content-Type header', function() {
@@ -109,7 +109,7 @@ describe('annotations api', function() {
         });
 
         it('should use endpoint https://api.mendeley.com/annotations/', function() {
-            expect(ajaxRequest.url).toBe(baseUrl + '/annotations/');
+            expect(ajaxRequest.url).toBe(baseUrl + '/annotations');
         });
 
         it('should have a Content-Type header', function() {
@@ -269,7 +269,7 @@ describe('annotations api', function() {
                 expect(annotationsApi.paginationLinks.next).toEqual(linkNext);
                 expect(annotationsApi.paginationLinks.last).toEqual(linkLast);
                 expect(annotationsApi.paginationLinks.prev).toEqual(false);
-                
+
                 done();
             });
         });

--- a/test/spec/api/catalog.spec.js
+++ b/test/spec/api/catalog.spec.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 
 describe('catalog api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var catalogApi = api.catalog;
     var baseUrl = 'https://api.mendeley.com';
 

--- a/test/spec/api/documents.spec.js
+++ b/test/spec/api/documents.spec.js
@@ -12,7 +12,7 @@ function getFakeFile(name, type) {
 
 describe('documents api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var documentsApi = api.documents;
     var baseUrl = 'https://api.mendeley.com';
 
@@ -434,8 +434,8 @@ describe('documents api', function() {
             expect(ajaxRequest.method).toBe('get');
         });
 
-        it('should use endpoint /documents/', function() {
-            expect(ajaxRequest.url).toBe(baseUrl + '/documents/');
+        it('should use endpoint /documents', function() {
+            expect(ajaxRequest.url).toBe(baseUrl + '/documents');
         });
 
         it('should NOT have a Content-Type header', function() {
@@ -644,7 +644,7 @@ describe('documents api', function() {
             ajaxSpy();
             documentsApi.list().finally(function() {
                 expect(documentsApi.count).toEqual(155);
-                
+
                 sendMendeleyCountHeader = false;
                 documentCount = 999;
                 ajaxSpy();
@@ -669,7 +669,7 @@ describe('documents api', function() {
                 expect(documentsApi.paginationLinks.next).toEqual(linkNext);
                 expect(documentsApi.paginationLinks.last).toEqual(linkLast);
                 expect(documentsApi.paginationLinks.previous).toEqual(linkPrev);
-                
+
                 sendLinks = false;
                 ajaxSpy();
                 return documentsApi.retrieve(155);
@@ -688,7 +688,7 @@ describe('documents api', function() {
                 expect(documentsApi.paginationLinks.next).toEqual(linkNext);
                 expect(documentsApi.paginationLinks.last).toEqual(linkLast);
                 expect(documentsApi.paginationLinks.previous).toEqual(linkPrev);
-                
+
                 documentsApi.resetPagination();
 
                 expect(documentsApi.paginationLinks.next).toEqual(false);

--- a/test/spec/api/files.spec.js
+++ b/test/spec/api/files.spec.js
@@ -6,7 +6,7 @@ var Bluebird = require('bluebird');
 
 describe('files api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var filesApi = api.files;
     var baseUrl = 'https://api.mendeley.com';
 

--- a/test/spec/api/folders.spec.js
+++ b/test/spec/api/folders.spec.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 
 describe('folders api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var foldersApi = api.folders;
     var baseUrl = 'https://api.mendeley.com';
 
@@ -245,8 +245,8 @@ describe('folders api', function() {
             expect(ajaxRequest.method).toBe('get');
         });
 
-        it('should use endpoint /folders/', function() {
-            expect(ajaxRequest.url).toBe(baseUrl + '/folders/');
+        it('should use endpoint /folders', function() {
+            expect(ajaxRequest.url).toBe(baseUrl + '/folders');
         });
 
         it('should NOT have a Content-Type header', function() {
@@ -336,14 +336,14 @@ describe('folders api', function() {
             ajaxSpy();
             foldersApi.list().finally(function() {
                 expect(foldersApi.count).toEqual(56);
-                
+
                 sendMendeleyCountHeader = false;
                 folderCount = 999;
                 ajaxSpy();
                 return foldersApi.list();
             }).finally(function() {
                 expect(foldersApi.count).toEqual(56);
-                
+
                 sendMendeleyCountHeader = true;
                 folderCount = 0;
                 ajaxSpy();

--- a/test/spec/api/followers.spec.js
+++ b/test/spec/api/followers.spec.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 
 describe('followers api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var followersApi = api.followers;
     var baseUrl = 'https://api.mendeley.com';
 

--- a/test/spec/api/groups.spec.js
+++ b/test/spec/api/groups.spec.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 
 describe('groups api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var groupApi = api.groups;
     var baseUrl = 'https://api.mendeley.com';
 
@@ -34,8 +34,8 @@ describe('groups api', function() {
             expect(ajaxRequest.method).toBe('get');
         });
 
-        it('should use endpoint /groups/', function() {
-            expect(ajaxRequest.url).toBe(baseUrl + '/groups/');
+        it('should use endpoint /groups', function() {
+            expect(ajaxRequest.url).toBe(baseUrl + '/groups');
         });
 
         it('should NOT have a Content-Type header', function() {

--- a/test/spec/api/institution-trees.spec.js
+++ b/test/spec/api/institution-trees.spec.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 
 describe('institution trees api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var institutionTreesApi = api.institutionTrees;
     var baseUrl = 'https://api.mendeley.com';
 
@@ -19,7 +19,7 @@ describe('institution trees api', function() {
         var params = {
             institution_id: '123'
         };
-        
+
         beforeEach(function(done) {
             ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
             institutionTreesApi.list(params).finally(function() {
@@ -59,7 +59,7 @@ describe('institution trees api', function() {
     describe('retrieve method', function() {
         var ajaxSpy;
         var ajaxRequest;
-        
+
         beforeEach(function(done) {
             ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
             institutionTreesApi.retrieve('123').finally(function() {

--- a/test/spec/api/institutions.spec.js
+++ b/test/spec/api/institutions.spec.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 
 describe('institutions api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var institutionsApi = api.institutions;
     var baseUrl = 'https://api.mendeley.com';
 

--- a/test/spec/api/locations.spec.js
+++ b/test/spec/api/locations.spec.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 
 describe('locations api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var locationsApi = api.locations;
     var baseUrl = 'https://api.mendeley.com';
 

--- a/test/spec/api/metadata.spec.js
+++ b/test/spec/api/metadata.spec.js
@@ -6,7 +6,7 @@ var Bluebird = require('bluebird');
 
 describe('metadata api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var metadataApi = api.metadata;
     var baseUrl = 'https://api.mendeley.com';
 

--- a/test/spec/api/profiles.spec.js
+++ b/test/spec/api/profiles.spec.js
@@ -6,7 +6,7 @@ var Bluebird = require('bluebird');
 
 describe('profiles api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var profilesApi = api.profiles;
     var baseUrl = 'https://api.mendeley.com';
 
@@ -138,11 +138,11 @@ describe('profiles api', function() {
         });
 
     });
-    
+
     describe('retrieve by email method', function() {
         var ajaxSpy;
         var ajaxRequest;
-        
+
         beforeEach(function(done) {
             ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
             profilesApi.retrieveByEmail('test@test.com').finally(function() {

--- a/test/spec/api/trash.spec.js
+++ b/test/spec/api/trash.spec.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 
 describe('trash api', function() {
 
-    var api = require('../../../lib/api');
+    var api = require('../../../').API;
     var trashApi = api.trash;
     var baseUrl = 'https://api.mendeley.com';
 
@@ -73,8 +73,8 @@ describe('trash api', function() {
             expect(ajaxRequest.method).toBe('get');
         });
 
-        it('should use endpoint /trash/', function() {
-            expect(ajaxRequest.url).toBe(baseUrl + '/trash/');
+        it('should use endpoint /trash', function() {
+            expect(ajaxRequest.url).toBe(baseUrl + '/trash');
         });
 
         it('should NOT have a Content-Type header', function() {

--- a/test/spec/auth/auth.spec.js
+++ b/test/spec/auth/auth.spec.js
@@ -154,4 +154,57 @@ describe('auth', function() {
         });
 
     });
+
+    describe('client credentials auth flow', function() {
+
+        it('should require a client id', function() {
+            expect(function () {
+                auth.clientCredentialsFlow();
+            }).toThrow();
+        });
+
+        it('should require a client secret', function() {
+            expect(function () {
+                auth.clientCredentialsFlow({
+                    clientId: 5
+                });
+            }).toThrow();
+        });
+
+        it('should require a redirect uri', function() {
+            expect(function () {
+                auth.clientCredentialsFlow({
+                    clientId: 5,
+                    clientSecret: 'sssh'
+                });
+            }).toThrow();
+        });
+
+        it('should fetch an access token', function(done) {
+            var authFlow = auth.clientCredentialsFlow({
+                clientId: 5,
+                clientSecret: 'sssh',
+                redirectUri: 'https://example.com/foo'
+            });
+
+            var accessToken = 'accessToken';
+            var ajaxSpy = spyOn(axios, 'post').and.returnValue(Bluebird.resolve({
+                data: {
+                    'access_token': accessToken
+                }
+            }));
+
+            expect(authFlow.getToken()).toBeUndefined();
+
+            authFlow.refreshToken()
+            .then(function () {
+                expect(authFlow.getToken()).toEqual(accessToken);
+
+                done();
+            });
+
+            expect(ajaxSpy).toHaveBeenCalled();
+        });
+
+    });
 });

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -5,8 +5,7 @@ describe('utilities', function() {
     var mockAuth = require('../../mocks/auth');
     var axios = require('axios');
     var Bluebird = require('bluebird');
-
-    utils.setAuthFlow(mockAuth.mockImplicitGrantFlow());
+    var authFlow = mockAuth.mockImplicitGrantFlow();
 
     describe('requestWithFileFun', function() {
         var ajaxSpy;
@@ -22,8 +21,19 @@ describe('utilities', function() {
                 name: 'fileName',
                 type: 'text/plain'
             };
-            var requestFunction = utils.requestWithFileFun('POST', 'url', 'link', {
+            var requestFunction = utils.requestWithFileFun({
+              authFlow: function () {
+                return authFlow;
+              },
+              baseUrl: function () {
+                return 'url';
+              },
+              method: 'POST',
+              resource: 'resource',
+              linkType: 'link',
+              headers: {
                 'Content-Type': 'text/html'
+              }
             });
 
             requestFunction(file).finally(function() {


### PR DESCRIPTION
Setting the authFlow object multiple times clobbers the previous reference meaning you can't use it server as subsequent requests will overwrite the auth tokens for previous requests.

This PR allows you to create multiple instances of the api to be stored on [`res.locals`](http://expressjs.com/en/api.html#res.locals) or [`request.plugins`](http://hapijs.com/api#request-object) etc.

It also changes the internal utilities module to use an options object to avoid [boolean trap](https://ariya.io/2011/08/hall-of-api-shame-boolean-trap)s and adds [nyc](https://libraries.io/npm/nyc) for jasmine-serial code coverage.