### PR TITLE
Add mime types to all methods

### DIFF
--- a/lib/api/annotations.js
+++ b/lib/api/annotations.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Annotations API
@@ -9,10 +10,6 @@ var utils = require('../utilities');
  * @name api.annotations
  */
 module.exports = function annotations(options) {
-
-    var dataHeaders = {
-        annotation: { 'Content-Type': 'application/vnd.mendeley-annotation.1+json' }
-    };
 
     return {
 
@@ -29,7 +26,10 @@ module.exports = function annotations(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/annotations/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.ANNOTATION
+            }
         }),
 
         /**
@@ -47,7 +47,10 @@ module.exports = function annotations(options) {
             method: 'PATCH',
             resource: '/annotations/{id}',
             args: ['id'],
-            headers: dataHeaders.annotation,
+            headers: {
+              'Content-Type': MIME_TYPES.ANNOTATION,
+              'Accept': MIME_TYPES.ANNOTATION
+            },
             followLocation: true
         }),
 
@@ -64,7 +67,10 @@ module.exports = function annotations(options) {
             baseUrl: options.baseUrl,
             method: 'POST',
             resource: '/annotations',
-            headers: dataHeaders.annotation,
+            headers: {
+              'Content-Type': MIME_TYPES.ANNOTATION,
+              'Accept': MIME_TYPES.ANNOTATION
+            },
             followLocation: true
         }),
 
@@ -95,7 +101,10 @@ module.exports = function annotations(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/annotations'
+            resource: '/annotations',
+            headers: {
+              'Accept': MIME_TYPES.ANNOTATION
+            }
         }),
 
         /**

--- a/lib/api/catalog.js
+++ b/lib/api/catalog.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Catalog API
@@ -23,7 +24,10 @@ module.exports = function catalog(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/catalog'
+            resource: '/catalog',
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         }),
 
         /**
@@ -40,7 +44,10 @@ module.exports = function catalog(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/catalog/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         })
 
     };

--- a/lib/api/documents.js
+++ b/lib/api/documents.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Documents API
@@ -9,25 +10,25 @@ var utils = require('../utilities');
  * @name api.documents
  */
 module.exports = function documents(options) {
-    var dataHeaders = {
-            'Content-Type': 'application/vnd.mendeley-document.1+json'
-        },
-        cloneDataHeaders = {
-            'Content-Type': 'application/vnd.mendeley-document-clone.1+json'
-        },
 
-        listDocuments = utils.requestFun({
+    var listDocuments = utils.requestFun({
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/documents'
+            resource: '/documents',
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         }),
         listFolder = utils.requestFun({
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/folders/{id}/documents',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         });
 
     return {
@@ -45,7 +46,10 @@ module.exports = function documents(options) {
             baseUrl: options.baseUrl,
             method: 'POST',
             resource: '/documents',
-            headers: dataHeaders,
+            headers: {
+              'Content-Type': MIME_TYPES.DOCUMENT,
+              'Accept': MIME_TYPES.DOCUMENT
+            },
             followLocation: true
         }),
 
@@ -61,7 +65,10 @@ module.exports = function documents(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'POST',
-            resource: '/documents'
+            resource: '/documents',
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         }),
 
         /**
@@ -78,7 +85,10 @@ module.exports = function documents(options) {
             baseUrl: options.baseUrl,
             method: 'POST',
             resource: '/documents',
-            linkType: 'group'
+            linkType: 'group',
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         }),
 
         /**
@@ -94,7 +104,10 @@ module.exports = function documents(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/documents/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         }),
 
         /**
@@ -112,7 +125,10 @@ module.exports = function documents(options) {
             method: 'PATCH',
             resource: '/documents/{id}',
             args: ['id'],
-            headers: dataHeaders,
+            headers: {
+              'Content-Type': MIME_TYPES.DOCUMENT,
+              'Accept': MIME_TYPES.DOCUMENT
+            },
             followLocation: true
         }),
 
@@ -130,7 +146,10 @@ module.exports = function documents(options) {
             method: 'POST',
             resource: '/documents/{id}/actions/cloneTo',
             args: ['id'],
-            headers: cloneDataHeaders,
+            headers: {
+              'Content-Type': MIME_TYPES.DOCUMENT_CLONE,
+              'Accept': MIME_TYPES.DOCUMENT_CLONE
+            },
             followLocation: true
         }),
 
@@ -167,7 +186,10 @@ module.exports = function documents(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/search/documents'
+            resource: '/search/documents',
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         }),
 
         /**
@@ -183,8 +205,7 @@ module.exports = function documents(options) {
             baseUrl: options.baseUrl,
             method: 'POST',
             resource: '/documents/{id}/trash',
-            args: ['id'],
-            headers: dataHeaders
+            args: ['id']
         }),
 
         /**

--- a/lib/api/files.js
+++ b/lib/api/files.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Files API
@@ -9,7 +10,6 @@ var utils = require('../utilities');
  * @name api.files
  */
 module.exports = function files(options) {
-    var headers   = { 'Accept': 'application/vnd.mendeley-file.1+json' };
 
     return {
 
@@ -28,7 +28,9 @@ module.exports = function files(options) {
             baseUrl: options.baseUrl,
             method: 'POST',
             resource: '/files',
-            headers: headers,
+            headers: {
+              'Accept': MIME_TYPES.FILE
+            },
             linkType: 'document'
         }),
 
@@ -46,7 +48,9 @@ module.exports = function files(options) {
             method: 'GET',
             resource: '/files?document_id={id}',
             args: ['id'],
-            headers: headers
+            headers: {
+              'Accept': MIME_TYPES.FILE
+            }
         }),
 
         /**

--- a/lib/api/folders.js
+++ b/lib/api/folders.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 /**
  * Folders API
  *
@@ -8,10 +9,6 @@ var utils = require('../utilities');
  * @name api.folders
  */
 module.exports = function folders(options) {
-    var dataHeaders = {
-            folder: { 'Content-Type': 'application/vnd.mendeley-folder.1+json' },
-            'document': { 'Content-Type': 'application/vnd.mendeley-document.1+json' }
-        };
 
     return {
 
@@ -28,7 +25,10 @@ module.exports = function folders(options) {
             baseUrl: options.baseUrl,
             method: 'POST',
             resource: '/folders',
-            headers: dataHeaders.folder,
+            headers: {
+              'Content-Type': MIME_TYPES.FOLDER,
+              'Accept': MIME_TYPES.FOLDER
+            },
             followLocation: true
         }),
 
@@ -45,7 +45,10 @@ module.exports = function folders(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/folders/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.FOLDER
+            }
         }),
 
         /**
@@ -63,7 +66,10 @@ module.exports = function folders(options) {
             method: 'PATCH',
             resource: '/folders/{id}',
             args: ['id'],
-            headers: dataHeaders.folder,
+            headers: {
+              'Content-Type': MIME_TYPES.FOLDER,
+              'Accept': MIME_TYPES.FOLDER
+            },
             followLocation: true
         }),
 
@@ -97,8 +103,7 @@ module.exports = function folders(options) {
             baseUrl: options.baseUrl,
             method: 'DELETE',
             resource: '/folders/{id}/documents/{docId}',
-            args: ['id', 'docId'],
-            headers: dataHeaders.folder
+            args: ['id', 'docId']
         }),
 
         /**
@@ -115,7 +120,9 @@ module.exports = function folders(options) {
             method: 'POST',
             resource: '/folders/{id}/documents',
             args: ['id'],
-            headers: dataHeaders.document
+            headers: {
+              'Content-Type': MIME_TYPES.DOCUMENT
+            }
         }),
 
         /**
@@ -129,7 +136,10 @@ module.exports = function folders(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/folders'
+            resource: '/folders',
+            headers: {
+              'Accept': MIME_TYPES.FOLDER
+            }
         }),
 
         /**

--- a/lib/api/followers.js
+++ b/lib/api/followers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Followers API
@@ -9,14 +10,6 @@ var utils = require('../utilities');
  * @name api.followers
  */
 module.exports = function followers(options) {
-    var dataHeaders = {
-        create: {
-            'Content-Type': 'application/vnd.mendeley-follow-request.1+json'
-        },
-        accept: {
-            'Content-Type': 'application/vnd.mendeley-follow-acceptance.1+json'
-        }
-    };
 
     return {
 
@@ -37,7 +30,10 @@ module.exports = function followers(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/followers'
+            resource: '/followers',
+            headers: {
+              'Accept': MIME_TYPES.FOLLOW
+            }
         }),
 
         /**
@@ -58,7 +54,10 @@ module.exports = function followers(options) {
             baseUrl: options.baseUrl,
             method: 'POST',
             resource: '/followers',
-            headers: dataHeaders.create
+            headers: {
+              'Content-Type': MIME_TYPES.FOLLOW_REQUEST,
+              'Accept': MIME_TYPES.FOLLOW
+            }
         }),
 
         /**
@@ -95,7 +94,10 @@ module.exports = function followers(options) {
             method: 'PATCH',
             resource: '/followers/{id}',
             args: ['id'],
-            headers: dataHeaders.accept
+            headers: {
+              'Content-Type': MIME_TYPES.FOLLOW_ACCEPT,
+              'Accept': MIME_TYPES.FOLLOW
+            }
         })
 
     };

--- a/lib/api/groups.js
+++ b/lib/api/groups.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Groups API
@@ -24,7 +25,10 @@ module.exports = function groups(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/groups/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.GROUP
+            }
         }),
 
         /**
@@ -38,7 +42,10 @@ module.exports = function groups(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/groups'
+            resource: '/groups',
+            headers: {
+              'Accept': MIME_TYPES.GROUP
+            }
         }),
 
         /**

--- a/lib/api/institution-trees.js
+++ b/lib/api/institution-trees.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Institution trees API
@@ -23,7 +24,10 @@ module.exports = function institutionTrees(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/institution_trees'
+            resource: '/institution_trees',
+            headers: {
+              'Accept': MIME_TYPES.INSTITUTION_TREE
+            }
         }),
 
         /**
@@ -39,7 +43,10 @@ module.exports = function institutionTrees(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/institution_trees/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.INSTITUTION_TREE
+            }
         })
 
     };

--- a/lib/api/institutions.js
+++ b/lib/api/institutions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Institutions API
@@ -23,7 +24,10 @@ module.exports = function institutions(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/institutions'
+            resource: '/institutions',
+            headers: {
+              'Accept': MIME_TYPES.INSTITUTION
+            }
         }),
 
         /**
@@ -39,7 +43,10 @@ module.exports = function institutions(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/institutions/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.INSTITUTION
+            }
         })
 
     };

--- a/lib/api/locations.js
+++ b/lib/api/locations.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Locations API
@@ -23,7 +24,10 @@ module.exports = function locations(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/locations'
+            resource: '/locations',
+            headers: {
+              'Accept': MIME_TYPES.LOCATION
+            }
         }),
 
         /**
@@ -39,7 +43,10 @@ module.exports = function locations(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/locations/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.LOCATION
+            }
         })
 
     };

--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Metadata API
@@ -9,9 +10,6 @@ var utils = require('../utilities');
  * @name api.metadata
  */
 module.exports = function metadata(options) {
-    var dataHeaders = {
-            'Accept': 'application/vnd.mendeley-document-lookup.1+json'
-        };
 
     return {
 
@@ -28,7 +26,9 @@ module.exports = function metadata(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/metadata',
-            headers: dataHeaders
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT_LOOKUP
+            }
         })
 
     };

--- a/lib/api/profiles.js
+++ b/lib/api/profiles.js
@@ -1,11 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
-
-var MIME_TYPES = {
-  PROFILE: 'application/vnd.mendeley-profiles.1+json',
-  PROFILE_UPDATE: 'application/vnd.mendeley-profile-amendment.1+json'
-};
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Profiles API
@@ -14,6 +10,7 @@ var MIME_TYPES = {
  * @name api.profiles
  */
 module.exports = function profiles(options) {
+
     return {
 
         /**

--- a/lib/api/trash.js
+++ b/lib/api/trash.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('../utilities');
+var MIME_TYPES = require('../mime-types');
 
 /**
  * Trash API
@@ -24,7 +25,10 @@ module.exports = function trash(options) {
             baseUrl: options.baseUrl,
             method: 'GET',
             resource: '/trash/{id}',
-            args: ['id']
+            args: ['id'],
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         }),
 
         /**
@@ -38,7 +42,10 @@ module.exports = function trash(options) {
             authFlow: options.authFlow,
             baseUrl: options.baseUrl,
             method: 'GET',
-            resource: '/trash'
+            resource: '/trash',
+            headers: {
+              'Accept': MIME_TYPES.DOCUMENT
+            }
         }),
 
         /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 var api = require('./api');
 var auth = require('./auth');
 var request = require('./request');
+var mimeTypes = require('./mime-types');
 
 // Exports Mendeley SDK
 module.exports = function (options) {
@@ -43,6 +44,7 @@ module.exports = function (options) {
 
 module.exports.Auth = auth;
 module.exports.Request = request;
+module.exports.MimeTypes = mimeTypes;
 
 // this is to maintain backwards compatibility
 var authFlow = false;

--- a/lib/mime-types.js
+++ b/lib/mime-types.js
@@ -1,0 +1,18 @@
+
+module.exports = {
+    ANNOTATION: 'application/vnd.mendeley-annotation.1+json',
+    DOCUMENT: 'application/vnd.mendeley-document.1+json',
+    DOCUMENT_CLONE: 'application/vnd.mendeley-document-clone.1+json',
+    DOCUMENT_LOOKUP: 'application/vnd.mendeley-document-lookup.1+json',
+    FILE: 'application/vnd.mendeley-file.1+json',
+    FOLDER: 'application/vnd.mendeley-folder.1+json',
+    FOLLOW: 'application/vnd.mendeley-follow.1+json',
+    FOLLOW_REQUEST: 'application/vnd.mendeley-follow-request.1+json',
+    FOLLOW_ACCEPT: 'application/vnd.mendeley-follow-acceptance.1+json',
+    GROUP: 'application/vnd.mendeley-group.1+json',
+    INSTITUTION: 'application/vnd.mendeley-institution.1+json',
+    INSTITUTION_TREE: 'application/vnd.mendeley-institution-tree.1+json',
+    LOCATION: 'application/vnd.mendeley-location.1+json',
+    PROFILE: 'application/vnd.mendeley-profiles.1+json',
+    PROFILE_UPDATE: 'application/vnd.mendeley-profile-amendment.1+json'
+};

--- a/test/spec/api/documents.spec.js
+++ b/test/spec/api/documents.spec.js
@@ -508,10 +508,6 @@ describe('documents api', function() {
             expect(ajaxRequest.url).toBe(baseUrl + '/documents/15/trash');
         });
 
-        it('should have a Content-Type header', function() {
-            expect(ajaxRequest.headers['Content-Type']).toBeDefined();
-        });
-
         it('should have an Authorization header', function() {
             expect(ajaxRequest.headers.Authorization).toBeDefined();
             expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');


### PR DESCRIPTION
* Collects mime type definitions in one place
* Exports mime types on module export

There was a test that asserted having a `Content-Type` for `POST /documents/{id}/trash` but the platform service behind that resource does not expect a `Content-Type` so I removed it.