### PR TITLE
Fix headers in documents.clone method

### DIFF
--- a/lib/api/documents.js
+++ b/lib/api/documents.js
@@ -148,7 +148,7 @@ module.exports = function documents(options) {
             args: ['id'],
             headers: {
               'Content-Type': MIME_TYPES.DOCUMENT_CLONE,
-              'Accept': MIME_TYPES.DOCUMENT_CLONE
+              'Accept': MIME_TYPES.DOCUMENT
             },
             followLocation: true
         }),


### PR DESCRIPTION
Accept header for this method should be `application/vnd.mendeley-document.1+json` not `application/vnd.mendeley-document-clone.1+json`