### PR TITLE
capture axios error response

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -49,8 +49,8 @@ function send(request) {
     }).then(onDone.bind(this)).catch(onFail.bind(this));
 }
 
-function onFail(response) {
-    switch (response.status) {
+function onFail(error) {
+    switch (error.response.status) {
         case 0:
         case 504:
             // 504 Gateway timeout or communication error
@@ -58,7 +58,7 @@ function onFail(response) {
                 this.retries++;
                 return this.send();
             } else {
-                throw response;
+                throw error;
             }
             break;
 
@@ -69,12 +69,12 @@ function onFail(response) {
                 return refreshToken.call(this);
             } else {
                 this.settings.authFlow.authenticate();
-                throw response;
+                throw error;
             }
             break;
 
         default:
-            throw response;
+            throw error;
     }
 }
 

--- a/test/mocks/auth.js
+++ b/test/mocks/auth.js
@@ -3,13 +3,13 @@
 var Bluebird = require('bluebird');
 
 var unauthorisedError = new Error();
-unauthorisedError.status = 401;
+unauthorisedError.response = { status: 401 };
 
 var timeoutError = new Error();
-timeoutError.status = 504;
+timeoutError.response = { status: 504 };
 
 var notFoundError = new Error();
-notFoundError.status = 404;
+notFoundError.response = { status: 404 };
 
 module.exports = {
     mockImplicitGrantFlow: mockImplicitGrantFlow,

--- a/test/spec/api/documents.spec.js
+++ b/test/spec/api/documents.spec.js
@@ -74,9 +74,9 @@ describe('documents api', function() {
         }
     });
 
-    var mockPromiseNotFound = Bluebird.reject({ status: 404 });
+    var mockPromiseNotFound = Bluebird.reject({ response: { status: 404 } });
 
-    var mockPromiseInternalError = Bluebird.reject({ status: 500 });
+    var mockPromiseInternalError = Bluebird.reject({ response: { status: 500 } });
 
     // Get a function to return promises in order
     function getMockPromises() {
@@ -167,16 +167,16 @@ describe('documents api', function() {
 
         it('should reject create errors with the request and response', function(done) {
             spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseInternalError));
-            documentsApi.create({ title: 'foo' }).catch(function(response) {
-                expect(response.status).toEqual(500);
+            documentsApi.create({ title: 'foo' }).catch(function(error) {
+                expect(error.response.status).toEqual(500);
                 done();
             });
         });
 
         it('should fail redirect errors with the request and the response', function(done) {
             spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseCreate, mockPromiseNotFound));
-            documentsApi.create({ title: 'foo' }).catch(function(response) {
-                expect(response.status).toEqual(404);
+            documentsApi.create({ title: 'foo' }).catch(function(error) {
+                expect(error.response.status).toEqual(404);
                 done();
             });
         });
@@ -321,8 +321,8 @@ describe('documents api', function() {
 
         it('should reject retrieve errors with the request and response', function(done) {
             spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseNotFound));
-            documentsApi.list().catch(function(response) {
-                expect(response.status).toEqual(404);
+            documentsApi.list().catch(function(error) {
+                expect(error.response.status).toEqual(404);
                 done();
             });
         });
@@ -528,7 +528,7 @@ describe('documents api', function() {
         var ajaxSpy;
 
         it('should retry on 504', function(done) {
-            ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(Bluebird.reject({ status: 504 }), mockPromiseList));
+            ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(Bluebird.reject({ response: { status: 504 } }), mockPromiseList));
             documentsApi.list().then(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 expect(ajaxSpy.calls.count()).toBe(2);
@@ -537,7 +537,7 @@ describe('documents api', function() {
         });
 
         it('should only retry once', function(done) {
-            ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(Bluebird.reject({ status: 504 }), Bluebird.reject({ status: 504 }), mockPromiseList));
+            ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(Bluebird.reject({ response: { status: 504 } }), Bluebird.reject({ response: { status: 504 } }), mockPromiseList));
             documentsApi.list().catch(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 expect(ajaxSpy.calls.count()).toBe(2);
@@ -644,7 +644,7 @@ describe('documents api', function() {
             ajaxSpy();
             documentsApi.list().finally(function() {
                 expect(documentsApi.count).toEqual(155);
-                
+
                 sendMendeleyCountHeader = false;
                 documentCount = 999;
                 ajaxSpy();
@@ -669,7 +669,7 @@ describe('documents api', function() {
                 expect(documentsApi.paginationLinks.next).toEqual(linkNext);
                 expect(documentsApi.paginationLinks.last).toEqual(linkLast);
                 expect(documentsApi.paginationLinks.previous).toEqual(linkPrev);
-                
+
                 sendLinks = false;
                 ajaxSpy();
                 return documentsApi.retrieve(155);
@@ -688,7 +688,7 @@ describe('documents api', function() {
                 expect(documentsApi.paginationLinks.next).toEqual(linkNext);
                 expect(documentsApi.paginationLinks.last).toEqual(linkLast);
                 expect(documentsApi.paginationLinks.previous).toEqual(linkPrev);
-                
+
                 documentsApi.resetPagination();
 
                 expect(documentsApi.paginationLinks.next).toEqual(false);

--- a/test/spec/api/folders.spec.js
+++ b/test/spec/api/folders.spec.js
@@ -112,11 +112,11 @@ describe('folders api', function() {
 
         it('should reject create errors with the response', function(done) {
             var ajaxFailureResponse = function() {
-                return Bluebird.reject({ status: 500 });
+                return Bluebird.reject({ response: { status: 500 } });
             };
             spyOn(axios, 'request').and.callFake(ajaxFailureResponse);
-            foldersApi.create({ name: 'foo' }).catch(function(response) {
-                expect(response.status).toEqual(500);
+            foldersApi.create({ name: 'foo' }).catch(function(error) {
+                expect(error.response.status).toEqual(500);
                 done();
             });
         });
@@ -135,12 +135,12 @@ describe('folders api', function() {
                 }
                 // But following the location fails
                 else {
-                    return Bluebird.reject({ status: 404 });
+                    return Bluebird.reject({ response: { status: 404 } });
                 }
             };
             spyOn(axios, 'request').and.callFake(ajaxMixedResponse);
-            foldersApi.create({ name: 'foo' }).catch(function(response) {
-                expect(response.status).toEqual(404);
+            foldersApi.create({ name: 'foo' }).catch(function(error) {
+                expect(error.response.status).toEqual(404);
                 done();
             });
         });
@@ -336,14 +336,14 @@ describe('folders api', function() {
             ajaxSpy();
             foldersApi.list().finally(function() {
                 expect(foldersApi.count).toEqual(56);
-                
+
                 sendMendeleyCountHeader = false;
                 folderCount = 999;
                 ajaxSpy();
                 return foldersApi.list();
             }).finally(function() {
                 expect(foldersApi.count).toEqual(56);
-                
+
                 sendMendeleyCountHeader = true;
                 folderCount = 0;
                 ajaxSpy();

--- a/test/spec/api/trash.spec.js
+++ b/test/spec/api/trash.spec.js
@@ -130,11 +130,11 @@ describe('trash api', function() {
     describe('restore method failures', function() {
         it('should reject restore errors with the response', function(done) {
             var ajaxFailureResponse = function() {
-                return Bluebird.reject({ status: 404 });
+                return Bluebird.reject({ response: { status: 404 } });
             };
             spyOn(axios, 'request').and.callFake(ajaxFailureResponse);
-            trashApi.restore().catch(function(response) {
-                expect(response.status).toEqual(404);
+            trashApi.restore().catch(function(error) {
+                expect(error.response.status).toEqual(404);
                 done();
             });
         });

--- a/test/spec/request/request.spec.js
+++ b/test/spec/request/request.spec.js
@@ -50,7 +50,7 @@ describe('request', function() {
             var mockAuthInterface = mockAuth.mockAuthCodeFlow();
             var myRequest = request.create({ method: 'get' }, { authFlow: mockAuthInterface });
             var fun = getMockPromises(
-                Bluebird.reject({ status: 401 }), // Auth failure
+                Bluebird.reject({ response: { status: 401 } }), // Auth failure
                 Bluebird.resolve({ status: 200, headers: {} }) // Original request success
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
@@ -69,7 +69,7 @@ describe('request', function() {
             var mockAuthInterface = mockAuth.mockAuthCodeFlow();
             var myRequest = request.create({ method: 'get' }, { authFlow: mockAuthInterface });
             var fun = getMockPromises(
-                Bluebird.reject({ status: 401 }), // Auth failure
+                Bluebird.reject({ response: { status: 401 } }), // Auth failure
                 Bluebird.resolve({ status: 200, headers: {} }) // Original request success
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);


### PR DESCRIPTION
Request fail handler wasn't capturing the response status as the existing code was trying to switch on `response.status` rather than `error.response.status`. Request and affected specs updated. 

@paulwib @charliehw