### PR TITLE
Use wrapper for list results

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ define(function(require) {
 
 API resources that implement `list` functions return paginated responses.
 
-These add a `total` property that represents the total number of resources and some of `firstPage`, `nextPage`, `previousPage` and `lastPage` methods that return promises which resolve to the first, next, previous and last page of resources respectively.
+These have a `total` property that represents the total number of resources and some of `firstPage`, `nextPage`, `previousPage` and `lastPage` methods that return promises which resolve to the first, next, previous and last page of resources respectively.
+
+The actual resources loaded are accessible by the `page` property.
 
 The presence of the pagination methods depend on where in the collection you are at the time.  If you are on the first page of results for example, the `firstPage` method will not be present.  Similarly if there is only one page of results there will be no pagination methods available.
 
@@ -250,25 +252,25 @@ The presence of the pagination methods depend on where in the collection you are
 var api = require('@mendeley/api')(options);
 
 api.documents.list()
-.then(function (documents) {
-  console.info('There are ' + documents.total + ' documents in total');
+.then(function (result) {
+  console.info('There are ' + result.total + ' documents in total');
 
-  console.info('The first page of documents is ' + documents);
+  console.info('The first page of documents is ' + result.page);
 
-  return documents.nextPage();
+  return result.nextPage();
 })
-.then(function (documents) {
-  console.info('The next page of documents is ' + documents);
+.then(function (result) {
+  console.info('The next page of documents is ' + result.page);
 
-  return documents.previousPage();
+  return result.previousPage();
 })
-.then(function (documents) {
-  console.info('The previous page of documents is ' + documents);
+.then(function (result) {
+  console.info('The previous page of documents is ' + result.page);
 
-  return documents.lastPage();
+  return result.lastPage();
 })
-.then(function (documents) {
-  console.info('The last page of documents is ' + documents);
+.then(function (result) {
+  console.info('The last page of documents is ' + result.page);
 });
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -139,3 +139,19 @@ https://github.com/mzabriskie/axios#global-axios-defaults
   })
   api.documents.list().then(/* ... */)
   ```
+
+## Upgrading to v5.x
+
+1. Pagination has been tweaked again. Now the result of calls to `list` methods is a wrapper object that holds the actual list of resources under a property named `items`.
+
+  Also `nextPage`, `previousPage`, `firstPage` and `lastPage` become `next`, `previous`, `first` and `last` resepectively:
+
+  ```javascript
+  api.documents.list()
+  .then(function (page) {
+    console.info('I have ' + page.total + 'documents')
+    console.info('The documents are ' + page.items)
+
+    return page.next()
+  })
+  ```

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -24,12 +24,14 @@ function dataFilter(options, response) {
 }
 
 function paginationFilter (options, response) {
-  var headers = response.headers || {}
-  var output = response.data || []
-  output.total = output.length;
+  var headers = response.headers || {};
+  var page = {
+    items: response.data || []
+  };
+  page.total = page.items.length;
 
   if (headers.hasOwnProperty('mendeley-count')) {
-      output.total = parseInt(headers['mendeley-count'], 10);
+      page.total = parseInt(headers['mendeley-count'], 10);
   }
 
   if (headers.link) {
@@ -38,7 +40,7 @@ function paginationFilter (options, response) {
         return
       }
 
-      output[name + 'Page'] = function() {
+      page[name] = function() {
           var request = {
               method: 'GET',
               responseType: 'json',
@@ -58,7 +60,7 @@ function paginationFilter (options, response) {
     });
   }
 
-  return output;
+  return page;
 }
 
 function normaliseOptions(options) {

--- a/test/spec/api/annotations.spec.js
+++ b/test/spec/api/annotations.spec.js
@@ -214,10 +214,10 @@ describe('annotations api', function() {
             ajaxSpy();
 
             annotationsApi.list().then(function(annotations) {
-                expect(annotations.firstPage).toEqual(jasmine.any(Function));
-                expect(annotations.nextPage).toEqual(jasmine.any(Function));
-                expect(annotations.lastPage).toEqual(jasmine.any(Function));
-                expect(annotations.previousPage).toEqual(undefined);
+                expect(annotations.first).toEqual(jasmine.any(Function));
+                expect(annotations.next).toEqual(jasmine.any(Function));
+                expect(annotations.last).toEqual(jasmine.any(Function));
+                expect(annotations.previous).toEqual(undefined);
                 done();
             }).catch(function() {});
         });
@@ -225,8 +225,8 @@ describe('annotations api', function() {
         it('should get correct link on nextPage()', function(done) {
             var spy = ajaxSpy();
 
-            annotationsApi.list().then(function(annotations) {
-                return annotations.nextPage();
+            annotationsApi.list().then(function(page) {
+                return page.next();
             })
             .finally(function() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
@@ -237,8 +237,8 @@ describe('annotations api', function() {
         it('should get correct link on lastPage()', function(done) {
             var spy = ajaxSpy();
 
-            annotationsApi.list().then(function(anotations) {
-                return anotations.lastPage();
+            annotationsApi.list().then(function(page) {
+                return page.last();
             })
             .finally(function() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
@@ -249,8 +249,8 @@ describe('annotations api', function() {
         it('should store the total document count', function(done) {
             ajaxSpy();
 
-            annotationsApi.list().then(function(anotations) {
-                expect(anotations.total).toEqual(56);
+            annotationsApi.list().then(function(page) {
+                expect(page.total).toEqual(56);
                 done();
             });
         });

--- a/test/spec/api/documents.spec.js
+++ b/test/spec/api/documents.spec.js
@@ -593,20 +593,20 @@ describe('documents api', function() {
             ajaxSpy();
 
             documentsApi.list()
-            .then(function(documents) {
-                expect(documents.nextPage).toEqual(jasmine.any(Function));
-                expect(documents.lastPage).toEqual(jasmine.any(Function));
-                expect(documents.previousPage).toEqual(jasmine.any(Function));
+            .then(function(page) {
+                expect(page.next).toEqual(jasmine.any(Function));
+                expect(page.last).toEqual(jasmine.any(Function));
+                expect(page.previous).toEqual(jasmine.any(Function));
                 done();
             });
         });
 
-        it('should get correct link on nextPage()', function(done) {
+        it('should get correct link on next()', function(done) {
             var spy = ajaxSpy();
 
             documentsApi.list()
-            .then(function(documents) {
-                return documents.nextPage();
+            .then(function(page) {
+                return page.next();
             })
             .finally(function () {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
@@ -614,12 +614,12 @@ describe('documents api', function() {
             });
         });
 
-        it('should get correct link on previousPage()', function(done) {
+        it('should get correct link on previous()', function(done) {
             var spy = ajaxSpy();
 
             documentsApi.list()
-            .then(function(documents) {
-                return documents.previousPage();
+            .then(function(page) {
+                return page.previous();
             })
             .finally(function () {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkPrev);
@@ -631,8 +631,8 @@ describe('documents api', function() {
             var spy = ajaxSpy();
 
             documentsApi.list()
-            .then(function(documents) {
-                return documents.lastPage();
+            .then(function(page) {
+                return page.last();
             })
             .finally(function () {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
@@ -643,24 +643,24 @@ describe('documents api', function() {
         it('should store the total document count', function(done) {
             ajaxSpy();
             documentsApi.list()
-            .then(function (documents) {
-                expect(documents.total).toEqual(155);
+            .then(function (page) {
+                expect(page.total).toEqual(155);
 
                 sendMendeleyCountHeader = false;
                 documentCount = 999;
                 ajaxSpy();
                 return documentsApi.list();
             })
-            .then(function (documents) {
-                expect(documents.total).toEqual(0);
+            .then(function (page) {
+                expect(page.total).toEqual(0);
 
                 sendMendeleyCountHeader = true;
                 documentCount = 0;
                 ajaxSpy();
                 return documentsApi.list();
             })
-            .then(function (documents) {
-                expect(documents.total).toEqual(0);
+            .then(function (page) {
+                expect(page.total).toEqual(0);
                 done();
             });
         });
@@ -673,11 +673,11 @@ describe('documents api', function() {
             ajaxSpy();
 
             documentsApi.list()
-            .then(function(documents) {
-                expect(documents.total).toEqual(10);
-                expect(documents.nextPage).toEqual(undefined);
-                expect(documents.lastPage).toEqual(undefined);
-                expect(documents.previousPage).toEqual(undefined);
+            .then(function(page) {
+                expect(page.total).toEqual(10);
+                expect(page.next).toEqual(undefined);
+                expect(page.last).toEqual(undefined);
+                expect(page.previous).toEqual(undefined);
                 done();
             });
         });

--- a/test/spec/api/folders.spec.js
+++ b/test/spec/api/folders.spec.js
@@ -297,21 +297,21 @@ describe('folders api', function() {
             ajaxSpy();
 
             foldersApi.list()
-            .then(function (folders) {
-                expect(folders.nextPage).toEqual(jasmine.any(Function));
-                expect(folders.lastPage).toEqual(jasmine.any(Function));
-                expect(folders.previousPage).toEqual(undefined);
+            .then(function (page) {
+                expect(page.next).toEqual(jasmine.any(Function));
+                expect(page.last).toEqual(jasmine.any(Function));
+                expect(page.previous).toEqual(undefined);
                 done();
             });
 
         });
 
-        it('should get correct link on nextPage()', function(done) {
+        it('should get correct link on next()', function(done) {
             var spy = ajaxSpy();
 
             foldersApi.list()
-            .then(function (folders) {
-                return folders.nextPage();
+            .then(function (page) {
+                return page.next();
             })
             .finally(function () {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
@@ -319,12 +319,12 @@ describe('folders api', function() {
             });
         });
 
-        it('should get correct link on lastPage()', function(done) {
+        it('should get correct link on last()', function(done) {
             var spy = ajaxSpy();
 
             foldersApi.list()
-            .then(function (folders) {
-                return folders.lastPage();
+            .then(function (page) {
+                return page.last();
             })
             .finally(function () {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
@@ -335,24 +335,24 @@ describe('folders api', function() {
         it('should store the total document count', function(done) {
             ajaxSpy();
             foldersApi.list()
-            .then(function (folders) {
-                expect(folders.total).toEqual(56);
+            .then(function (page) {
+                expect(page.total).toEqual(56);
 
                 sendMendeleyCountHeader = false;
                 folderCount = 999;
                 ajaxSpy();
                 return foldersApi.list();
             })
-            .then(function (folders) {
-                expect(folders.total).toEqual(0);
+            .then(function (page) {
+                expect(page.total).toEqual(0);
 
                 sendMendeleyCountHeader = true;
                 folderCount = 0;
                 ajaxSpy();
                 return foldersApi.list();
             })
-            .then(function (folders) {
-                expect(folders.total).toEqual(0);
+            .then(function (page) {
+                expect(page.total).toEqual(0);
                 done();
             });
         });

--- a/test/spec/api/groups.spec.js
+++ b/test/spec/api/groups.spec.js
@@ -107,18 +107,18 @@ describe('groups api', function() {
 
             groupApi.list()
             .then(function (groups) {
-                expect(groups.nextPage).toEqual(jasmine.any(Function));
-                expect(groups.lastPage).toEqual(jasmine.any(Function));
-                expect(groups.previousPage).toEqual(undefined);
+                expect(groups.next).toEqual(jasmine.any(Function));
+                expect(groups.last).toEqual(jasmine.any(Function));
+                expect(groups.previous).toEqual(undefined);
                 done();
             });
         });
 
-        it('should get correct link on nextPage()', function(done) {
+        it('should get correct link on next()', function(done) {
             var spy = ajaxSpy();
 
-            groupApi.list().then(function(groups) {
-                return groups.nextPage();
+            groupApi.list().then(function(page) {
+                return page.next();
             })
             .finally(function() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
@@ -126,11 +126,11 @@ describe('groups api', function() {
             });
         });
 
-        it('should get correct link on lastPage()', function(done) {
+        it('should get correct link on last()', function(done) {
             var spy = ajaxSpy();
 
-            groupApi.list().then(function(groups) {
-                return groups.lastPage();
+            groupApi.list().then(function(page) {
+                return page.last();
             })
             .finally(function() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
@@ -142,8 +142,8 @@ describe('groups api', function() {
             ajaxSpy();
 
             groupApi.list()
-            .then(function (groups) {
-                expect(groups.total).toEqual(56);
+            .then(function (page) {
+                expect(page.total).toEqual(56);
                 done();
             });
         });

--- a/test/spec/api/trash.spec.js
+++ b/test/spec/api/trash.spec.js
@@ -211,18 +211,18 @@ describe('trash api', function() {
 
             trashApi.list()
             .then(function (trash) {
-                expect(trash.nextPage).toEqual(jasmine.any(Function));
-                expect(trash.lastPage).toEqual(jasmine.any(Function));
-                expect(trash.previousPage).toEqual(undefined);
+                expect(trash.next).toEqual(jasmine.any(Function));
+                expect(trash.last).toEqual(jasmine.any(Function));
+                expect(trash.previous).toEqual(undefined);
                 done();
             });
         });
 
-        it('should get correct link on nextPage()', function(done) {
+        it('should get correct link on next()', function(done) {
             var spy = ajaxSpy();
 
-            trashApi.list().then(function(trash) {
-                return trash.nextPage();
+            trashApi.list().then(function(page) {
+                return page.next();
             })
             .finally(function() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
@@ -230,11 +230,11 @@ describe('trash api', function() {
             });
         });
 
-        it('should get correct link on lastPage()', function(done) {
+        it('should get correct link on last()', function(done) {
             var spy = ajaxSpy();
 
-            trashApi.list().then(function(trash) {
-                return trash.lastPage();
+            trashApi.list().then(function(page) {
+                return page.last();
             })
             .finally(function() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
@@ -246,8 +246,8 @@ describe('trash api', function() {
             ajaxSpy();
 
             trashApi.list()
-            .then(function(trash) {
-                expect(trash.total).toEqual(155);
+            .then(function(page) {
+                expect(page.total).toEqual(155);
                 done();
             });
         });


### PR DESCRIPTION
With hindsight adding methods to the result array was a bad idea because it's too easy to do this sort of thing by accident:

```javascript
api.documents.list()
.then(documents => documents.map(transform))
.then(transformed => {
  display(transformed)

  return transformed.nextPage() // kaboom!
})
```

With this change you'd do:

```javascript
api.documents.list()
.then(page => {
  display(page.items.map(transform))

  return page.next() // ok!
})
```

With the current code it is true that you could do:

```javascript
api.documents.list()
.then(documents => {
  display(documents.map(transform))

  return documents.nextPage() // ok!
})
```

But you still have the problem of accidentally stripping the pagination methods by using array methods - it's too easy to shoot yourself in the foot.