### PR TITLE
Guard on error.request before trying to access error.request.status

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -61,6 +61,10 @@ function send(request) {
 }
 
 function onFail(error) {
+    if(!error.response) {
+        throw error;
+    }
+
     switch (error.response.status) {
         case 0:
         case 504:

--- a/test/spec/request/request.spec.js
+++ b/test/spec/request/request.spec.js
@@ -195,5 +195,19 @@ describe('request', function() {
                 expect(ajaxSpy.calls.count()).toEqual(1);
             }).finally(done);
         });
+
+        it('should survive vanilla Errors', function(done) {
+            var error = new Error('Kaboom!');
+            var myRequest = request.create({ method: 'get' }, { maxRetries: 1, authFlow: mockAuth.mockImplicitGrantFlow() });
+            var fun = getMockPromises(
+                Bluebird.reject(error),
+                Bluebird.resolve({ status: 200, headers: {} })
+            );
+            spyOn(axios, 'request').and.callFake(fun);
+
+            myRequest.send().catch(function(e) {
+                expect(e).toEqual(error);
+            }).finally(done);
+        });
     });
 });


### PR DESCRIPTION
Sometimes onFail can be handed regular node Error objects which don't have a `request` property, for example when using [nock](https://libraries.io/npm/nock) during tests.

This PR checks for the presence of an `error.response` property before trying to access `error.response.status`.
