### PR TITLE
Do not send multiple concurrent refresh token requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -110,9 +110,20 @@ function onDone(response) {
 }
 
 function refreshToken() {
+    var authFlow = this.settings.authFlow;
+
+    // if we are already in the middle of requesting an access token, wait for
+    // the result of that request instead of making a new one
+    if (authFlow._refreshTokenPromise) {
+        return authFlow._refreshTokenPromise.then(function () {
+            return this.send();
+        }.bind(this));
+    }
+
     var refresh = this.settings.authFlow.refreshToken();
+
     if (refresh) {
-        return refresh
+        var promise = refresh
             // If fails then we need to re-authenticate
             .catch(function(response) {
                 this.settings.authFlow.authenticate();
@@ -120,8 +131,16 @@ function refreshToken() {
             }.bind(this))
             // If OK update the access token and re-send the request
             .then(function() {
+                // Make sure we can request new refresh tokens in the future
+                delete authFlow._refreshTokenPromise;
+
+                // Resend the request
                 return this.send();
             }.bind(this));
+
+        authFlow._refreshTokenPromise = promise;
+
+        return promise;
     } else {
         this.settings.authFlow.authenticate();
         return Bluebird.reject(new Error('No token'));

--- a/test/mocks/auth.js
+++ b/test/mocks/auth.js
@@ -14,6 +14,7 @@ notFoundError.response = { status: 404 };
 module.exports = {
     mockImplicitGrantFlow: mockImplicitGrantFlow,
     mockAuthCodeFlow: mockAuthCodeFlow,
+    slowAuthCodeFlow: slowAuthCodeFlow,
     unauthorisedError: unauthorisedError,
     timeoutError: timeoutError,
     notFoundError: notFoundError
@@ -40,4 +41,23 @@ function mockAuthCodeFlow() {
             return Bluebird.resolve();
         }
     };
+}
+
+function slowAuthCodeFlow() {
+  var fakeToken = null;
+  var refreshCount = 0;
+
+  return {
+      getToken: function() { return fakeToken; },
+      authenticate: function() { return false; },
+      refreshToken: function() {
+          return new Bluebird(function (resolve) {
+              setTimeout(function () {
+                  refreshCount++;
+                  fakeToken = 'auth-refreshed-' + refreshCount;
+                  resolve();
+              }, 1000);
+          });
+      }
+  };
 }


### PR DESCRIPTION
When we send a request to the api, if a 401 is received we ask the auth flow object to refresh it's token before resending the original request.

If we send 5 concurrent requests (for example) that would mean that we might end up sending 5 concurrent refresh token requests.

This PR changes the refresh mechanism to store the first refresh promise on the auth flow object.  Any subsequent token refresh will resolve on this cached promise until it itself resolves, after which the cached promise is removed.