### PR TITLE
No longer throwing when refreshing a token fails

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -128,11 +128,6 @@ function refreshToken() {
 
     if (refresh) {
         var promise = refresh
-            // If fails then we need to re-authenticate
-            .catch(function(response) {
-                this.settings.authFlow.authenticate();
-                throw response;
-            }.bind(this))
             // If OK update the access token and re-send the request
             .then(function() {
                 // Make sure we can request new refresh tokens in the future
@@ -140,6 +135,10 @@ function refreshToken() {
 
                 // Resend the request
                 return this.send();
+            }.bind(this))
+            // If fails then we need to re-authenticate
+            .catch(function(response) {
+                this.settings.authFlow.authenticate();
             }.bind(this));
 
         authFlow._refreshTokenPromise = promise;

--- a/test/spec/request/request.spec.js
+++ b/test/spec/request/request.spec.js
@@ -92,7 +92,7 @@ describe('request', function() {
             var authRefreshSpy = spyOn(mockAuthInterface, 'refreshToken').and.returnValue(Bluebird.reject({ status: 500 }));
             var authAuthenticateSpy = spyOn(mockAuthInterface, 'authenticate').and.callThrough();
 
-            myRequest.send().catch(function() {
+            myRequest.send().then(function() {
                 expect(ajaxSpy.calls.count()).toEqual(1);
                 expect(authRefreshSpy.calls.count()).toEqual(1);
                 expect(authAuthenticateSpy.calls.count()).toEqual(1);


### PR DESCRIPTION
Some auth flows use refresh tokens that do expire so we shouldn't be propagating a exception when refreshing fails and authFlow.authenticate should be trusted to handle it.