### PR TITLE
Document search results are paginated as well

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -155,3 +155,21 @@ https://github.com/mzabriskie/axios#global-axios-defaults
     return page.next()
   })
   ```
+
+
+## Upgrading to v6.x
+
+1. Pagination has been added to the `document.search` method. Now, the result looks like what calls to `list` methods would return.
+
+  ```javascript
+  api.documents.search(searchParams)
+  .then(function (firstResultPage) {
+    console.info('I have ' + firstResultPage.total + 'search result items in total');
+    console.info('The items on the first page are ' + firstResultPage.items);
+
+    return firstResultPage.next();
+  })
+  .then(function (secondResultPage) {
+    console.info('Now I am on the next page')
+  });
+  ```

--- a/lib/api/documents.js
+++ b/lib/api/documents.js
@@ -191,7 +191,8 @@ module.exports = function documents(options) {
             resource: '/search/documents',
             headers: {
               'Accept': MIME_TYPES.DOCUMENT
-            }
+            },
+            responseFilter: utils.paginationFilter
         }),
 
         /**


### PR DESCRIPTION
Just like the case of `list`, the response from the request to `search` will contain a Mendeley-Count header containing the total number of search result items; this information should be made available. As well as the next/previous/etc. functions.