### PR TITLE
Generic method for making requests to GET /profiles 

### DIFF
--- a/lib/api/profiles.js
+++ b/lib/api/profiles.js
@@ -77,35 +77,53 @@ module.exports = function profiles(options) {
          * @param {string} email - Email address
          * @returns {promise}
          */
-         retrieveByEmail: utils.requestFun({
-             authFlow: options.authFlow,
-             baseUrl: options.baseUrl,
-             method: 'GET',
-             resource: '/profiles?email={email}',
-             args: ['email'],
-             headers: {
-               Accept: MIME_TYPES.PROFILE
-             }
-         }),
-
-         /**
-          * Retrieve a profile by link
-          *
-          * @method
-          * @memberof api.profiles
-          * @param {string} link - Short name
-          * @returns {promise}
-          */
-          retrieveByLink: utils.requestFun({
-              authFlow: options.authFlow,
-              baseUrl: options.baseUrl,
-              method: 'GET',
-              resource: '/profiles?link={link}',
-              args: ['link'],
-              headers: {
+        retrieveByEmail: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/profiles?email={email}',
+            args: ['email'],
+            headers: {
                 Accept: MIME_TYPES.PROFILE
-              }
-          })
+            }
+        }),
+
+        /**
+         * Retrieve a profile by link
+         *
+         * @method
+         * @memberof api.profiles
+         * @param {string} link - Short name
+         * @returns {promise}
+         */
+        retrieveByLink: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/profiles?link={link}',
+            args: ['link'],
+            headers: {
+                Accept: MIME_TYPES.PROFILE
+            }
+        }),
+
+        /**
+         * Retrieve profiles by identifiers
+         *
+         * @method
+         * @memberof api.profiles
+         * @param {object} params - Parameters to pass to GET /profiles
+         * @returns {promise}
+         */
+        retrieveByIdentifier: utils.requestFun({
+            authFlow: options.authFlow,
+            baseUrl: options.baseUrl,
+            method: 'GET',
+            resource: '/profiles',
+            headers: {
+                Accept: MIME_TYPES.PROFILE
+            }
+        })
 
     };
 };

--- a/test/spec/api/profiles.spec.js
+++ b/test/spec/api/profiles.spec.js
@@ -176,5 +176,42 @@ describe('profiles api', function() {
             expect(ajaxRequest.data).not.toBeDefined();
         });
     });
+
+    describe('retrieve by identifier method', function() {
+        var ajaxSpy;
+
+        beforeEach(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+        });
+
+        it('should pass scopus id through to the api request', function(done) {
+            var params = {
+                scopus_author_id: '12345'
+            };
+
+            profilesApi.retrieveByIdentifier(params).finally(function() {
+                var ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
+
+                expect(ajaxSpy).toHaveBeenCalled();
+                expect(ajaxRequest.params).toBe(params);
+                done();
+            });
+        });
+
+        it('should pass link paramter through to the api request', function(done) {
+            var params = {
+                link: 'hermione-granger'
+            };
+
+            profilesApi.retrieveByIdentifier(params).finally(function() {
+                var ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
+
+                expect(ajaxSpy).toHaveBeenCalled();
+                expect(ajaxRequest.params).toBe(params);
+                done();
+            });
+        });
+    });
+
 });
 /* jshint camelcase: true */


### PR DESCRIPTION
(i.e. using a slug, email address, catalog id, or author id)

This deprecates retrieveByLink and retrieveByEmail because you can just do this:

`api.profiles.retrieveByIdenfifier({ link: 'some-slug' });`
or this:
`api.profiles.retrieveByIdentifier({ email: 'something@something.something' });`

This also enables us to lookup profiles by scopus author id.