### PR TITLE
If refreshing an access token fails, we ought to authenticate

### DIFF
--- a/lib/auth/authenticated-flow.js
+++ b/lib/auth/authenticated-flow.js
@@ -1,9 +1,15 @@
 'use strict';
 
+var noop = require('./noop');
+
 module.exports = function authenticatedFlow(token) {
     return {
+        authenticate: function() {
+            throw new Error('Cannot authenticate');
+        },
         getToken: function() {
             return token;
-        }
+        },
+        refreshToken: noop
     };
 };

--- a/lib/auth/client-credentials-flow.js
+++ b/lib/auth/client-credentials-flow.js
@@ -15,7 +15,10 @@ module.exports = function clientCredentialsFlow(options) {
     redirectUri: undefined,
     scope: defaults.OAUTH_DEFAULT_SCOPE,
     onAccessToken: noop,
-    onNotAuthenticated: noop
+    onNotAuthenticated: function() {
+      // Client credentials auth flow only refreshes
+      throw new Error('Cannot authenticate');
+    }
   }, options);
 
   need(settings.clientId, 'You must provide a clientId for client credentials flow');
@@ -23,30 +26,30 @@ module.exports = function clientCredentialsFlow(options) {
   need(settings.redirectUri, 'You must provide a redirectUri for client credentials flow');
 
   return {
-      authenticate: settings.onNotAuthenticated,
-      getToken: function () {
-        return settings.accessToken;
-      },
-      refreshToken: function () {
-        return axios.post(settings.tokenUrl, formUrlEncoded({
-          'grant_type': 'client_credentials',
-          'client_id': settings.clientId,
-          'client_secret': settings.clientSecret,
-          'redirect_uri': settings.redirectUri,
-          'scope': settings.scope
-        }))
-        .then(function (result) {
-          /*jshint camelcase: false */
-          var expiresIn = result.data.expires_in * 1000;
+    authenticate: settings.onNotAuthenticated,
+    getToken: function () {
+      return settings.accessToken;
+    },
+    refreshToken: function () {
+      return axios.post(settings.tokenUrl, formUrlEncoded({
+        'grant_type': 'client_credentials',
+        'client_id': settings.clientId,
+        'client_secret': settings.clientSecret,
+        'redirect_uri': settings.redirectUri,
+        'scope': settings.scope
+      }))
+      .then(function (result) {
+        /*jshint camelcase: false */
+        var expiresIn = result.data.expires_in * 1000;
 
-          settings.accessToken = result.data.access_token;
-          settings.onAccessToken(settings.accessToken, expiresIn);
+        settings.accessToken = result.data.access_token;
+        settings.onAccessToken(settings.accessToken, expiresIn);
 
-          return {
-            accessToken: settings.accessToken,
-            expiresIn: expiresIn
-          };
-        });
-      }
+        return {
+          accessToken: settings.accessToken,
+          expiresIn: expiresIn
+        };
+      });
+    }
   };
 };

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -1,27 +1,9 @@
 'use strict';
 
-var noop = require('./noop');
-
-function wrap (auth) {
-  if (!auth.authenticate) {
-    auth.authenticate = noop;
-  }
-
-  if (!auth.getToken) {
-    auth.getToken = noop;
-  }
-
-  if (!auth.refreshToken) {
-    auth.refreshToken = noop;
-  }
-
-  return auth;
-}
-
 module.exports = {
-    implicitGrantFlow: wrap(require('./implicit-grant-flow')),
-    authCodeFlow: wrap(require('./auth-code-flow')),
-    authenticatedFlow: wrap(require('./authenticated-flow')),
-    clientCredentialsFlow: wrap(require('./client-credentials-flow')),
-    refreshTokenFlow: wrap(require('./refresh-token-flow'))
+    implicitGrantFlow: require('./implicit-grant-flow'),
+    authCodeFlow: require('./auth-code-flow'),
+    authenticatedFlow: require('./authenticated-flow'),
+    clientCredentialsFlow: require('./client-credentials-flow'),
+    refreshTokenFlow: require('./refresh-token-flow')
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -59,7 +59,7 @@ function send(request) {
 }
 
 function onFail(error) {
-    if(!error.response) {
+    if (!error.response) {
         throw error;
     }
 
@@ -126,6 +126,15 @@ function refreshToken() {
 
     if (refresh) {
         var promise = refresh
+            // If fails then we need to re-authenticate
+            .catch(function(refreshError) {
+                try {
+                    this.settings.authFlow.authenticate();
+                } catch(authenticationError) {
+                    // If authenticate throws, we want to propagate the refresh error
+                    throw refreshError;
+                }
+            }.bind(this))
             // If OK update the access token and re-send the request
             .then(function() {
                 // Make sure we can request new refresh tokens in the future
@@ -133,14 +142,6 @@ function refreshToken() {
 
                 // Resend the request
                 return this.send();
-            }.bind(this))
-            // If fails then we need to re-authenticate
-            .catch(function(response) {
-                if (response.status === 401) {
-                    return this.settings.authFlow.authenticate();
-                }
-
-                throw response;
             }.bind(this));
 
         authFlow._refreshTokenPromise = promise;

--- a/test/mocks/auth.js
+++ b/test/mocks/auth.js
@@ -25,7 +25,7 @@ function mockImplicitGrantFlow() {
 
     return {
         getToken: function() { return fakeToken; },
-        authenticate: function() { return false; },
+        authenticate: function() {},
         refreshToken: function () { return false; }
     };
 }
@@ -35,7 +35,7 @@ function mockAuthCodeFlow() {
 
     return {
         getToken: function() { return fakeToken; },
-        authenticate: function() { return false; },
+        authenticate: function() { throw new Error('Cannot authenticate'); },
         refreshToken: function() {
             fakeToken = 'auth-refreshed';
             return Bluebird.resolve();
@@ -49,7 +49,7 @@ function slowAuthCodeFlow() {
 
   return {
       getToken: function() { return fakeToken; },
-      authenticate: function() { return false; },
+      authenticate: function() {},
       refreshToken: function() {
           return new Bluebird(function (resolve) {
               setTimeout(function () {


### PR DESCRIPTION
...regardless of the status of the api response. However, we want to propagate the refresh error if the auth flow cannot authenticate (i.e. because it is client credentials)

I removed the wrapping that was happening in auth/index.js because it was adding those noops to the auth flow factories, which doesn't really help.