### PR TITLE
PaginationFilter: Build pagination methods from serialised properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,22 +257,60 @@ api.documents.list()
 
   console.info('The first page of documents is ' + result.page);
 
-  return result.nextPage();
+  return result.next();
 })
 .then(function (result) {
   console.info('The next page of documents is ' + result.page);
 
-  return result.previousPage();
+  return result.previous();
 })
 .then(function (result) {
   console.info('The previous page of documents is ' + result.page);
 
-  return result.lastPage();
+  return result.last();
 })
 .then(function (result) {
   console.info('The last page of documents is ' + result.page);
 });
 ```
+
+### "Handshake" between server and client.
+
+Sometimes its useful to be able to render from the server and paginate the rest from the client-side javascript. `pagination.decorate` method is ueful for adding the standard pagination methods from a stringified page result. Heres an example with expressjs.
+
+```javascript
+// server.js
+var express = require('express');
+var app = express();
+var api = require('@mendeley/api')(options);
+
+app.get('/', function (req, res) {
+
+  api.documents.list()
+  .then(function(result) {
+      res.send('<script>');
+      res.send('window.__data=' + JSON.stringify(result) + ';');
+      res.send('</script>')
+      res.end();
+  });
+});
+```
+```javascript
+// client.js
+var api = require('@mendeley/api');
+var pagination = require('@mendeley/api/pagination')
+
+// build pagination object with paging methods from the stringified object
+var page = pagination.decorate(window.__data, authFlow);
+
+// call the next page of pagination
+page.next()
+.then(function(result) {
+  // add the new page
+});
+
+```
+
 
 ## Examples
 

--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -23,6 +23,11 @@ module.exports = {
 function decorate(data, authFlow) {
     var page = assign({}, data);
 
+    if(!data.pageData || !data.pageData.link || typeof data.pageData.link!=='object') {
+        // soft fail
+        return page;
+    }
+
     PAGINATION_LINKS.forEach(function (name) {
         var url = data.pageData.link[name];
         if(url) {
@@ -72,7 +77,7 @@ function filter (options, response) {
  * Gets a handler that fetches the paginated page.
  *
  * @param {string} url of the pagination link
- * @param {function} authFlow the endeley authflow to use.
+ * @param {function} authFlow the mendeley authflow to use.
  * @param {object} headers to pass in the request.
  * @param {function} [responseFilter] - Optional filter to control which part of the response the promise resolves with
  */

--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -1,0 +1,127 @@
+
+var Request = require('./request');
+var PAGINATION_LINKS = ['first', 'previous', 'next', 'last'];
+var assign = require('object-assign');
+
+
+module.exports = {
+    filter : filter,
+    decorate : decorate
+};
+
+
+/**
+ * Decorates pagination response with the methods for next/previous/first/last.
+ * Used generally for building pagination object from a server called api response. For example:
+ *
+ * window.__data = JSON.stringify(serverPagination);
+ * var clientPagination = pagination.decorate(window.__data);
+ *
+ * @param {object} data, the pagination.filter object without the handlers.
+ * @param {function} authFlow the mendeley authflow to use.
+ */
+function decorate(data, authFlow) {
+    var page = assign({}, data);
+
+    PAGINATION_LINKS.forEach(function (name) {
+        var url = data.pageData.link[name];
+        if(url) {
+            page[name] = getPaginationHandler(url, authFlow, data.pageData.headers);
+        }
+    });
+    return page;
+}
+
+/**
+ * A responseFilter. Processes the api response and returns items and pagination information.
+ * @param {object} options
+ * @param {object} response the service response
+ * @returns pagination object with items, total and methods to call next, previous, last, first.
+ */
+function filter (options, response) {
+    var headers = response.headers || {};
+    var page = {
+        items: response.data || []
+    };
+    page.total = page.items.length;
+
+    if (headers.hasOwnProperty('mendeley-count')) {
+        page.total = parseInt(headers['mendeley-count'], 10);
+    }
+
+    page.pageData = {
+        link: {},
+        headers: options.headers
+    };
+
+    if (headers.link) {
+        PAGINATION_LINKS.forEach(function (name) {
+            if (!headers.link[name]) {
+                return
+            }
+            page[name] = getPaginationHandler(headers.link[name], options.authFlow, options.headers, options.responseFilter);
+            page.pageData.link[name] = headers.link[name];
+        });
+    }
+
+    return page;
+}
+
+
+/**
+ * Gets a handler that fetches the paginated page.
+ *
+ * @param {string} url of the pagination link
+ * @param {function} authFlow the endeley authflow to use.
+ * @param {object} headers to pass in the request.
+ * @param {function} [responseFilter] - Optional filter to control which part of the response the promise resolves with
+ */
+function getPaginationHandler(url, authFlow, headers, responseFilter) {
+    var request = {
+        method: 'GET',
+        responseType: 'json',
+        url: url,
+        headers: getRequestHeaders(headers)
+    };
+
+    var settings = {
+        maxRetries: 1,
+        authFlow: authFlow
+    };
+
+    if (typeof settings.authFlow === 'function') {
+        settings.authFlow = authFlow();
+    }
+
+    var options = {
+        headers: headers,
+        authFlow: authFlow,
+        responseFilter: responseFilter || filter
+    };
+
+    return function () {
+        return Request.create(request, settings)
+            .send()
+            .then(options.responseFilter.bind(null, options));
+    };
+}
+
+
+/**
+ * Get the headers for a request
+ *
+ * @private
+ * @param {array} headers
+ * @param {array} data
+ * @returns {array}
+ */
+function getRequestHeaders(headers, data) {
+    for (var headerName in headers) {
+        var val = headers[headerName];
+        if (typeof val === 'function') {
+            headers[headerName] = val(data);
+        }
+    }
+    return headers;
+}
+

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -16,13 +16,58 @@ module.exports = {
     requestWithDataFun: requestWithDataFun,
     requestWithFileFun: requestWithFileFun,
 
-    paginationFilter: paginationFilter
+    paginationFilter: paginationFilter,
+    getPaginationHandler: getPaginationHandler
 };
 
 function dataFilter(options, response) {
     return response.data;
 }
 
+/**
+ * gets a handler that fetches the paginated page
+ * 
+ * @param {string} Url of the pagination link
+ * @param {function} authFlow 
+ * @param {ojbect} headers to pass in the request.
+ * @param {function} [responseFilter] - Optional filter to control which part of the response the promise resolves with
+ */
+function getPaginationHandler(url, authFlow, headers, responseFilter) {
+    var request = {
+        method: 'GET',
+        responseType: 'json',
+        url: url,
+        headers: getRequestHeaders(headers)
+    };
+
+    var settings = {
+        maxRetries: 1,
+        authFlow: authFlow,
+    };
+
+    if (typeof settings.authFlow === 'function') {
+        settings.authFlow = authFlow();
+    }
+
+    var options = {
+        headers: headers,
+        authFlow: authFlow,
+        responseFilter: responseFilter || paginationFilter
+    };
+
+    return function () {
+        return Request.create(request, settings)
+            .send()
+            .then(options.responseFilter.bind(null, options));
+    };
+}
+
+/**
+ * gets methods to handle pagination
+ * @param {object} options
+ * @param {object} the service response
+ * @returns pagination object with items, total and methods to call next, previous, last, first.
+ */
 function paginationFilter (options, response) {
   var headers = response.headers || {};
   var page = {
@@ -34,30 +79,23 @@ function paginationFilter (options, response) {
       page.total = parseInt(headers['mendeley-count'], 10);
   }
 
+    page.headers = {
+        link: {},
+        accept: options.headers['Accept']
+    };
+
   if (headers.link) {
     PAGINATION_LINKS.forEach(function (name) {
       if (!headers.link[name]) {
         return
       }
 
-      page[name] = function() {
-          var request = {
-              method: 'GET',
-              responseType: 'json',
-              url: headers.link[name],
-              headers: getRequestHeaders(options.headers)
-          };
+            page[name] = getPaginationHandler(headers.link[name], options.authFlow, options.headers, options.responseFilter);
+            page.headers.link[name] = headers.link[name];
 
-          var settings = {
-              authFlow: options.authFlow(),
-              maxRetries: 1
-          };
-
-          return Request.create(request, settings)
-              .send()
-              .then(options.responseFilter.bind(null, options));
-      };
     });
+
+
   }
 
   return page;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,7 +3,7 @@
 var Request = require('./request');
 var assign = require('object-assign');
 var Bluebird = require('bluebird');
-var PAGINATION_LINKS = ['first', 'previous', 'next', 'last'];
+var pagination = require('./pagination');
 
 /**
  * Utilities
@@ -15,90 +15,11 @@ module.exports = {
     requestFun: requestFun,
     requestWithDataFun: requestWithDataFun,
     requestWithFileFun: requestWithFileFun,
-
-    paginationFilter: paginationFilter,
-    getPaginationHandler: getPaginationHandler
+    paginationFilter:  pagination.filter
 };
 
 function dataFilter(options, response) {
     return response.data;
-}
-
-/**
- * gets a handler that fetches the paginated page
- * 
- * @param {string} Url of the pagination link
- * @param {function} authFlow 
- * @param {ojbect} headers to pass in the request.
- * @param {function} [responseFilter] - Optional filter to control which part of the response the promise resolves with
- */
-function getPaginationHandler(url, authFlow, headers, responseFilter) {
-    var request = {
-        method: 'GET',
-        responseType: 'json',
-        url: url,
-        headers: getRequestHeaders(headers)
-    };
-
-    var settings = {
-        maxRetries: 1,
-        authFlow: authFlow,
-    };
-
-    if (typeof settings.authFlow === 'function') {
-        settings.authFlow = authFlow();
-    }
-
-    var options = {
-        headers: headers,
-        authFlow: authFlow,
-        responseFilter: responseFilter || paginationFilter
-    };
-
-    return function () {
-        return Request.create(request, settings)
-            .send()
-            .then(options.responseFilter.bind(null, options));
-    };
-}
-
-/**
- * gets methods to handle pagination
- * @param {object} options
- * @param {object} the service response
- * @returns pagination object with items, total and methods to call next, previous, last, first.
- */
-function paginationFilter (options, response) {
-  var headers = response.headers || {};
-  var page = {
-    items: response.data || []
-  };
-  page.total = page.items.length;
-
-  if (headers.hasOwnProperty('mendeley-count')) {
-      page.total = parseInt(headers['mendeley-count'], 10);
-  }
-
-    page.headers = {
-        link: {},
-        accept: options.headers['Accept']
-    };
-
-  if (headers.link) {
-    PAGINATION_LINKS.forEach(function (name) {
-      if (!headers.link[name]) {
-        return
-      }
-
-            page[name] = getPaginationHandler(headers.link[name], options.authFlow, options.headers, options.responseFilter);
-            page.headers.link[name] = headers.link[name];
-
-    });
-
-
-  }
-
-  return page;
 }
 
 function normaliseOptions(options) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "mversion": "^1.3.0",
     "nyc": "^8.3.0",
     "pre-commit": "^1.1.3",
+    "proxy-loader": "0.0.10",
+    "proxyquire": "^1.7.10",
     "serial-jasmine": "^0.1.1",
     "simple-oauth2": "^1.0.0",
     "webpack": "^1.8.5"

--- a/test/spec/pagination/pagination.spec.js
+++ b/test/spec/pagination/pagination.spec.js
@@ -1,0 +1,200 @@
+'use strict';
+
+var Bluebird = require('bluebird');
+var assign = require('object-assign');
+var pagination = require('../../../lib/pagination');
+var Request = require('../../../lib/request');
+var mockAuth = require('../../mocks/auth');
+
+var authFlow = mockAuth.mockImplicitGrantFlow();
+
+
+describe('pagination', function() {
+
+    var requestCreateSpy;
+    var responsePromise = Bluebird.resolve({
+        headers: {
+            Header: '123'
+        },
+        data: {
+            id: '456'
+        }
+    });
+
+    beforeEach(function() {
+        requestCreateSpy = spyOn(Request, 'create').and.returnValue({
+            send: function() {
+                return responsePromise;
+            }
+        });
+    });
+
+    describe('paginationFilter', function () {
+
+        var apiReponse = {
+            headers: {
+                link: {
+                    next: 'http://i.am.the.next.link',
+                    previous: 'http://i.am.the.previous.link',
+                    dontdo: 'something'
+                },
+                'mendeley-count': 199
+            },
+            data: [
+                { id: 1 }
+            ]
+        };
+
+        var options = {
+            authFlow: function () { return authFlow; },
+            baseUrl: 'baseUrl',
+            method: 'GET',
+            resource: '/communities/v1',
+            headers: {
+                'Accept': 'application/my/custom/mimetype',
+                'Development-Token': 'devToken'
+            },
+            responseFilter: function () { }
+        };
+
+        it('should return the correct pagination object with next/prev methods', function () {
+
+            var paginationResponse = pagination.filter(options, apiReponse);
+
+            expect(paginationResponse.total).toBe(199);
+            expect(paginationResponse.items).toEqual([
+                { id: 1 }
+            ]);
+            expect(paginationResponse.next).toBeDefined();
+            expect(paginationResponse.previous).toBeDefined();
+            expect(paginationResponse.first).not.toBeDefined();
+            expect(paginationResponse.last).not.toBeDefined();
+            expect(paginationResponse.dontdo).not.toBeDefined();
+
+            expect(paginationResponse.pageData.headers).toEqual({
+                Accept: 'application/my/custom/mimetype',
+                'Development-Token': 'devToken'
+            });
+            expect(paginationResponse.pageData.link).toEqual({
+                next: 'http://i.am.the.next.link',
+                previous: 'http://i.am.the.previous.link'
+            });
+
+        });
+
+        it('next link should call the correct endpoint', function () {
+
+            var paginationResponse = pagination.filter(options, apiReponse);
+            paginationResponse.next();
+
+            expect(requestCreateSpy).toHaveBeenCalledWith({
+                method: 'GET',
+                url: 'http://i.am.the.next.link',
+                headers: {
+                    Accept: 'application/my/custom/mimetype',
+                    'Development-Token': 'devToken'
+                },
+                responseType: 'json'
+            }, {
+                    authFlow: authFlow,
+                    maxRetries: 1
+                });
+        });
+
+    });
+
+    describe('decorate', function() {
+
+        var data = {
+            items: [],
+            total: 23,
+            pageData: {
+                headers: {
+                    accept: 'our-custom/json',
+                    custom: 'our-custom-header'
+                },
+                link: {
+                    next: 'http://a.next.url',
+                    previous: 'http://a.prev.url',
+                    last: 'http://a.last.url',
+                    first: 'http://a.first.url',
+                    dontuseme: 'http://dontuseme'
+                }
+            },
+            otherCustomProp: 'otherprop'
+        };
+
+        it('should add next previous last first methods and pass through the custom request headers', function() {
+
+            var result = pagination.decorate(data);
+
+            expect(result.pageData.headers.accept).toBe('our-custom/json');
+            expect(result.pageData.headers.custom).toBe('our-custom-header');
+        
+            expect(typeof result.next).toBe('function');
+            expect(typeof result.previous).toBe('function');
+            expect(typeof result.last).toBe('function');
+            expect(typeof result.first).toBe('function');
+            expect(result.dontuseme).not.toBeDefined();
+            expect(result.otherCustomProp).toBe('otherprop');
+        });
+
+        function expectRequestCall(expectedUrl) {
+            return {
+                method: 'GET',
+                url: expectedUrl,
+                headers: {
+                    accept: 'our-custom/json',
+                    custom: 'our-custom-header'
+                },
+                responseType: 'json'
+            };
+        }
+
+        var expectedOptions = {
+            maxRetries: 1,
+            authFlow: authFlow
+        };
+
+        it('should fire the correct request when the "next" handler is called', function() {
+            var result = pagination.decorate(data, authFlow);
+            result.next();
+            expect(requestCreateSpy).toHaveBeenCalledWith(expectRequestCall('http://a.next.url'), expectedOptions);
+        });
+
+        it('should fire the correct request when the "previous" handler is called', function() {
+            var result = pagination.decorate(data, authFlow);
+            result.previous();
+            expect(requestCreateSpy).toHaveBeenCalledWith(expectRequestCall('http://a.prev.url'), expectedOptions);
+        });
+
+        it('should fire the correct request when the "first" handler is called', function() {
+            var result = pagination.decorate(data, authFlow);
+            result.first();
+            expect(requestCreateSpy).toHaveBeenCalledWith(expectRequestCall('http://a.first.url'), expectedOptions);
+        });
+
+        it('should fire the correct request when the "last" handler is called', function() {
+            var result = pagination.decorate(data, authFlow);
+            result.last();
+            expect(requestCreateSpy).toHaveBeenCalledWith(expectRequestCall('http://a.last.url'), expectedOptions);
+        });
+
+        it('should handle partials links from the server', function() {
+            var partialData = assign({}, data);
+
+            delete partialData.pageData.link.previous;
+            delete partialData.pageData.link.last;
+            delete partialData.pageData.link.first;
+
+            var result = pagination.decorate(data, authFlow);
+
+            expect(typeof result.next).toBe('function');
+            expect(result.previous).not.toBeDefined();
+            expect(result.last).not.toBeDefined();
+            expect(result.first).not.toBeDefined();
+
+        });
+
+    });
+});

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -302,4 +302,104 @@ describe('utilities', function() {
         });
 
     });
+
+    describe('paginationFilter', function () {
+
+        var apiReponse = {
+            headers: {
+                link: {
+                    next: 'http://i.am.the.next.link',
+                    previous: 'http://i.am.the.previous.link',
+                    dontdo: 'something'
+                },
+                'mendeley-count': 199
+            },
+            data: [
+                { id: 1 }
+            ]
+        };
+
+        var options = {
+            authFlow: function () { return authFlow; },
+            baseUrl: 'baseUrl',
+            method: 'GET',
+            resource: '/communities/v1',
+            headers: {
+                'Accept': 'application/my/custom/mimetype',
+                'Development-Token': 'devToken'
+            },
+            responseFilter: function () { }
+        };
+
+        it('should return the correct pagination object with next/prev methods', function () {
+
+            var paginationResponse = utils.paginationFilter(options, apiReponse);
+
+            expect(paginationResponse.total).toBe(199);
+            expect(paginationResponse.items).toEqual([
+                { id: 1 }
+            ]);
+            expect(paginationResponse.next).toBeDefined();
+            expect(paginationResponse.previous).toBeDefined();
+            expect(paginationResponse.first).not.toBeDefined();
+            expect(paginationResponse.last).not.toBeDefined();
+            expect(paginationResponse.dontdo).not.toBeDefined();
+
+            expect(paginationResponse.headers).toEqual({
+                accept: 'application/my/custom/mimetype',
+                link: {
+                    next: 'http://i.am.the.next.link',
+                    previous: 'http://i.am.the.previous.link'
+                }
+            });
+
+        });
+
+        it('next link should call the correct endpoint', function () {
+
+            var paginationResponse = utils.paginationFilter(options, apiReponse);
+            paginationResponse.next();
+
+            expect(requestCreateSpy).toHaveBeenCalledWith({
+                method: 'GET',
+                url: 'http://i.am.the.next.link',
+                headers: {
+                    Accept: 'application/my/custom/mimetype',
+                    'Development-Token': 'devToken'
+                },
+                responseType: 'json'
+            }, {
+                    authFlow: authFlow,
+                    maxRetries: 1
+                });
+        });
+
+    });
+
+    describe('getPaginationHandler', function () {
+
+        it('should return a method that calls the correct endpoint', function () {
+
+            var handler = utils.getPaginationHandler('http://mylink?page=2', authFlow, {
+                'Accept': 'application/custom',
+                'Development-Token': 'devToken'
+            });
+
+            handler();
+
+            expect(requestCreateSpy).toHaveBeenCalledWith({
+                method: 'GET',
+                url: 'http://mylink?page=2',
+                headers: {
+                    Accept: 'application/custom',
+                    'Development-Token': 'devToken'
+                },
+                responseType: 'json'
+            }, {
+                    authFlow: authFlow,
+                    maxRetries: 1
+                });
+
+        });
+    });
 });


### PR DESCRIPTION
Added tests for existing paginationFilter. 
Added method to generate handler, exposed service links & headers needed to generate a pagination handler. 
Useful for handshake from server render to client.
 
