### PR TITLE
Send the progress handler to both onUploadProgress and onDownloadProgress

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -183,7 +183,8 @@ function requestWithFileFun(options) {
             url: url,
             headers: requestHeaders,
             data: file,
-            onUploadProgress: progressHandler
+            onUploadProgress: progressHandler,
+            onDownloadProgress: progressHandler
         };
 
         var settings = {

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -238,7 +238,8 @@ describe('utilities', function() {
                 url: 'https://api.mendeley.com/test',
                 headers: headers,
                 data: file,
-                onUploadProgress: undefined
+                onUploadProgress: undefined,
+                onDownloadProgress: undefined
             }, {
                 authFlow: authFlow
             });
@@ -273,7 +274,8 @@ describe('utilities', function() {
                 url: 'https://api.mendeley.com/test',
                 headers: headers,
                 data: file,
-                onUploadProgress: progressHandler
+                onUploadProgress: progressHandler,
+                onDownloadProgress: progressHandler
             }, {
                 authFlow: authFlow
             });
@@ -295,7 +297,8 @@ describe('utilities', function() {
                     Link: '<https://api.mendeley.com/documents/zelda>; rel="document"'
                 }, headers),
                 data: file,
-                onUploadProgress: undefined
+                onUploadProgress: undefined,
+                onDownloadProgress: undefined
             }, {
                 authFlow: authFlow
             });


### PR DESCRIPTION
Some services (e.g. Importer) needs download progress indicator.