### PR TITLE
protect against auth retries on send

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -32,8 +32,13 @@ function send(request) {
 
     // If no token at all (cookie deleted or expired), attempt to refresh token
     if (!token) {
-        this.authRetries++;
-        return refreshToken.call(this);
+        if (this.authRetries < this.settings.maxAuthRetries) {
+            this.authRetries++;
+            return refreshToken.call(this);
+        } else {
+            this.settings.authFlow.authenticate();
+            throw new Error('maxAuthRetries exceeded');
+        }
     }
 
     // remove any headers without values because axios objects to them


### PR DESCRIPTION
In the event that `authenticate` method on the passed in flow does not throw an error, there was an endless loop running. Now protecting against exceeding `maxAuthRetries` with the `Request.send` method.