### PR TITLE
prevent caching failing token requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -133,6 +133,9 @@ function refreshToken() {
         var promise = refresh
             // If fails then we need to re-authenticate
             .catch(function(refreshError) {
+                // Make sure we can request new refresh tokens in the future
+                delete authFlow._refreshTokenPromise;
+
                 try {
                     this.settings.authFlow.authenticate();
                 } catch(authenticationError) {


### PR DESCRIPTION
In the event that concurrent SDK calls are made and we do not have an access token, a single access token request should be sent and subsequent requests should stack behind the access token request.

The access token request promise is cached on the current auth flow object and if the call succeeds then we delete the reference to the promise. In the event of a failure the reference is not deleted and all subsequent sdk calls will fail for the current flow.

Deleting the access token when catching a refresh token request error, prevents this.