### PR TITLE
fix access token name

### DIFF
--- a/lib/auth/implicit-grant-flow.js
+++ b/lib/auth/implicit-grant-flow.js
@@ -11,7 +11,7 @@ function getAccessTokenCookieOrUrl(win, name) {
     var hashParts = (win.location.hash || '').split('=');
     var hash = null;
 
-    if (hashParts[0] === 'token') {
+    if (hashParts[0] === '#access_token') {
       hash = hashParts[1];
     }
 

--- a/test/spec/auth/auth.spec.js
+++ b/test/spec/auth/auth.spec.js
@@ -55,7 +55,7 @@ describe('auth', function() {
         });
 
         it('should read the access token from a URL hash', function() {
-            var win = mockWindow('https:', 'example.com', 'app', 'token=auth');
+            var win = mockWindow('https:', 'example.com', 'app', '#access_token=auth');
             var options = {win: win, clientId: 9999};
 
             var flow = auth.implicitGrantFlow(options);
@@ -63,7 +63,7 @@ describe('auth', function() {
         });
 
         it('should prefer an access token in the hash over the URL', function() {
-            var win = mockWindow('https:', 'example.com', 'app', 'token=hash-auth');
+            var win = mockWindow('https:', 'example.com', 'app', '#access_token=hash-auth');
             win.document.cookie = 'accessToken=cookie-auth';
             var options = {win: win, clientId: 9999};
 
@@ -144,7 +144,7 @@ describe('auth', function() {
         });
 
         it('should NOT read the access token from a URL hash', function() {
-            var win = mockWindow('https:', 'example.com', 'app', 'token=auth');
+            var win = mockWindow('https:', 'example.com', 'app', '#access_token=auth');
             var options = {win: win, clientId: 9999};
 
             var flow = auth.authCodeFlow(options);


### PR DESCRIPTION
The implicit grant flow was continuously returning to the Mendeley login screen, due to the SDK having the wrong name for the accesss token