### PR TITLE
use origin and pathname as default redirect url

### DIFF
--- a/lib/auth/implicit-grant-flow.js
+++ b/lib/auth/implicit-grant-flow.js
@@ -55,9 +55,9 @@ module.exports = function implicitGrantFlow(options) {
 
     need(settings.clientId, 'You must provide a clientId for implicit grant flow');
 
-    // OAuth redirect url defaults to current url
+    // OAuth redirect url defaults to current url, without hash part or querystring
     if (!settings.redirectUrl) {
-      settings.redirectUrl = settings.win.location.toString();
+      settings.redirectUrl = settings.win.location.origin.toString() + settings.win.location.pathname.toString();
     }
 
     var apiAuthenticateUrl = settings.apiAuthenticateUrl() +

--- a/lib/auth/implicit-grant-flow.js
+++ b/lib/auth/implicit-grant-flow.js
@@ -57,7 +57,7 @@ module.exports = function implicitGrantFlow(options) {
 
     // OAuth redirect url defaults to current url, without hash part or querystring
     if (!settings.redirectUrl) {
-      settings.redirectUrl = settings.win.location.origin.toString() + settings.win.location.pathname.toString();
+      settings.redirectUrl = settings.win.location.origin + settings.win.location.pathname;
     }
 
     var apiAuthenticateUrl = settings.apiAuthenticateUrl() +

--- a/test/mocks/window.js
+++ b/test/mocks/window.js
@@ -12,8 +12,9 @@ module.exports = function(protocol, host, pathname, hash) {
             host: host || 'example.com',
             pathname: pathname || '/foo',
             hash: hash || '',
+            origin: protocol + '//' + host,
             toString: function() {
-                return protocol + '//' + host + pathname + (hash ? '#' + hash : '');
+                return this.origin + this.pathname + (this.hash ? '#' + this.hash : '');
             }
         },
         document: {


### PR DESCRIPTION
I found that if I used the previous default (location) as the redirect, then upon return to my signin URL, then the api would fail with the 'URL doesn't match the one registered' message, due to the signin URL now having the access token appended in the hash part.

Simply use the origin and pathname instead so we can use the current URL as the default, and know it will matched that one registered with the client id

