### PR TITLE
Retry when service is temporarily unavailable

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -70,6 +70,8 @@ function onFail(error) {
 
     switch (error.response.status) {
         case 0:
+        case 503:
+            // 503 Service unavailable
         case 504:
             // 504 Gateway timeout or communication error
             if (this.retries < this.settings.maxRetries) {

--- a/test/mocks/auth.js
+++ b/test/mocks/auth.js
@@ -8,6 +8,9 @@ unauthorisedError.response = { status: 401 };
 var timeoutError = new Error();
 timeoutError.response = { status: 504 };
 
+var unavailableError = new Error();
+unavailableError.response = { status: 503 };
+
 var notFoundError = new Error();
 notFoundError.response = { status: 404 };
 
@@ -17,7 +20,8 @@ module.exports = {
     slowAuthCodeFlow: slowAuthCodeFlow,
     unauthorisedError: unauthorisedError,
     timeoutError: timeoutError,
-    notFoundError: notFoundError
+    notFoundError: notFoundError,
+    unavailableError: unavailableError
 };
 
 function mockImplicitGrantFlow() {

--- a/test/spec/request/request.spec.js
+++ b/test/spec/request/request.spec.js
@@ -284,6 +284,19 @@ describe('request', function() {
             }).finally(done);
         });
 
+        it('should retry when a service is temporarily unavailable', function(done) {
+            var myRequest = request.create({ method: 'get' }, { maxRetries: 5, authFlow: mockAuth.mockImplicitGrantFlow() });
+            var fun = getMockPromises(
+                Bluebird.reject(mockAuth.unavailableError),
+                Bluebird.resolve({ status: 200, headers: {} })
+            );
+            var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
+
+            myRequest.send().finally(function() {
+                expect(ajaxSpy.calls.count()).toEqual(2);
+            }).finally(done);
+        });
+
         it('should survive vanilla Errors', function(done) {
             var error = new Error('Kaboom!');
             var myRequest = request.create({ method: 'get' }, { maxRetries: 1, authFlow: mockAuth.mockImplicitGrantFlow() });


### PR DESCRIPTION
> 503 SERVICE UNAVAILABLE
> The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.

Adds retries when 503s are returned from the server.  Should help when running against staging..