### PR TITLE
Add search.catalog and document-types endpoints

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,6 +26,7 @@
         "before",
         "beforeEach",
         "beforeAll",
+        "afterEach",
         "fdescribe",
         "fit",
         "waitsFor",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "mendeley-javascript-sdk",
-  "version": "6.3.2",
+  "version": "6.3.4",
   "description": "Mendeley API JavaScript SDK",
   "repository": {
     "type": "git",

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,6 +2,7 @@
 
 var assign = require('object-assign');
 var Bluebird = require('bluebird');
+var utils = require('./utilities');
 
 Bluebird.config({
     warnings: false,
@@ -33,9 +34,9 @@ var endpointFactories = {
 function createEndpoints (options) {
   var endpoints = {};
 
-  Object.keys(endpointFactories).forEach(function(endpointName) {
-      endpoints[endpointName] = endpointFactories[endpointName](options);
-  });
+    Object.keys(endpointFactories).forEach(function(endpointName) {
+        endpoints[endpointName] = endpointFactories[endpointName](options, utils);
+    });
 
   return endpoints;
 }

--- a/lib/api/document-types.js
+++ b/lib/api/document-types.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var utils = require('../utilities');
 var MIME_TYPES = require('../mime-types');
 
 /**
@@ -9,7 +8,7 @@ var MIME_TYPES = require('../mime-types');
  * @namespace
  * @name api.documentTypes
  */
-module.exports = function documentTypes(options) {
+module.exports = function documentTypes(options, utils) {
     return {
 
         /**

--- a/lib/api/document-types.js
+++ b/lib/api/document-types.js
@@ -4,10 +4,10 @@ var utils = require('../utilities');
 var MIME_TYPES = require('../mime-types');
 
 /**
- * Search API
+ * Document Types API
  *
  * @namespace
- * @name api.search
+ * @name api.documentTypes
  */
 module.exports = function documentTypes(options) {
     return {

--- a/lib/api/search.js
+++ b/lib/api/search.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var utils = require('../utilities');
 var MIME_TYPES = require('../mime-types');
 
 /**
@@ -9,7 +8,7 @@ var MIME_TYPES = require('../mime-types');
  * @namespace
  * @name api.search
  */
-module.exports = function search(options) {
+module.exports = function search(options, utils) {
     return {
 
         /**

--- a/lib/api/search.js
+++ b/lib/api/search.js
@@ -27,7 +27,8 @@ module.exports = function search(options) {
             resource: '/search/catalog',
             headers: {
               'Accept': MIME_TYPES.DOCUMENT
-            }
+            },
+            responseFilter: utils.paginationFilter
         })
     };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendeley/api",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "description": "Mendeley API JavaScript SDK",
   "directories": {
     "example": "examples"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendeley/api",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "description": "Mendeley API JavaScript SDK",
   "directories": {
     "example": "examples"

--- a/test/mocks/apiOptions.js
+++ b/test/mocks/apiOptions.js
@@ -1,0 +1,4 @@
+module.exports = {
+    baseUrl: 'https://api.mendeley.com',
+    authFlow: function() {}
+};

--- a/test/mocks/utilities.js
+++ b/test/mocks/utilities.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+    requestFun: requestFun
+};
+
+function requestFun() { return requestFunction; }
+
+function requestFunction() {}

--- a/test/mocks/utilities.js
+++ b/test/mocks/utilities.js
@@ -1,9 +1,8 @@
 'use strict';
 
 module.exports = {
-    requestFun: requestFun
+    requestFun: function () { return requestFunction; },
+    paginationFilter: function() {}
 };
-
-function requestFun() { return requestFunction; }
 
 function requestFunction() {}

--- a/test/spec/api/document-types.spec.js
+++ b/test/spec/api/document-types.spec.js
@@ -1,17 +1,11 @@
 'use strict';
 
-var documentTypes = require('../../../lib/api/document-types');
+var utilitiesMock = require('../../mocks/utilities');
+var apiOptions = require('../../mocks/apiOptions');
 var MIME_TYPES = require('../../../lib/mime-types');
-
-// fixtures
-var apiOptions = {
-    baseUrl: 'https://api.mendeley.com',
-    authFlow: function() {}
-};
 
 // test globals
 var documentTypes;
-var requestFunSpy;
 
 // server/browser aware dependency injection helper
 function getDocumentTypesProxy() {
@@ -23,22 +17,22 @@ function getDocumentTypesProxy() {
 describe('documentTypes api', function() {
 
     beforeAll(function() {
-        requestFunSpy = jasmine.createSpy('requestFunSpy');
-        var utilitiesMock = { requestFun: requestFunSpy };
+        spyOn(utilitiesMock, 'requestFun').and.callThrough();
         documentTypes = getDocumentTypesProxy()({ '../utilities': utilitiesMock });
     });
+    afterEach(function() { utilitiesMock.requestFun.calls.reset(); });
 
     describe('when initialised', function() {
         it('calls utilities.requestFun with constructor options', function() {
             documentTypes(apiOptions);
-            expect(requestFunSpy).toHaveBeenCalledWith(
+            expect(utilitiesMock.requestFun).toHaveBeenCalledWith(
                 jasmine.objectContaining(apiOptions)
             );
         });
 
         it('calls utilities.requestFun with correct request setup', function() {
             documentTypes(apiOptions);
-            expect(requestFunSpy).toHaveBeenCalledWith(
+            expect(utilitiesMock.requestFun).toHaveBeenCalledWith(
                 jasmine.objectContaining({
                     method: 'GET',
                     resource: '/document_types',
@@ -47,9 +41,9 @@ describe('documentTypes api', function() {
             );
         });
 
-        it('returns api object with retrieve property', function() {
-            var documentTypesApiMethods = Object.keys(documentTypes(apiOptions));
-            expect(documentTypesApiMethods).toContain('retrieve');
+        it('returns api object with "retrieve" property containing the request function', function() {
+            var documentTypesApi = documentTypes(apiOptions);
+            expect(documentTypesApi.retrieve).toEqual(utilitiesMock.requestFun());
         });
     });
 

--- a/test/spec/api/document-types.spec.js
+++ b/test/spec/api/document-types.spec.js
@@ -3,35 +3,22 @@
 var utilitiesMock = require('../../mocks/utilities');
 var apiOptions = require('../../mocks/apiOptions');
 var MIME_TYPES = require('../../../lib/mime-types');
-
-// test globals
-var documentTypes;
-
-// server/browser aware dependency injection helper
-function getDocumentTypesProxy() {
-    return (typeof window !=='undefined') ?
-    require('proxy!../../../lib/api/document-types') :
-    require('proxyquire').bind(null, '../../../lib/api/document-types');
-}
+var documentTypes = require('../../../lib/api/document-types');
 
 describe('documentTypes api', function() {
-
-    beforeAll(function() {
-        spyOn(utilitiesMock, 'requestFun').and.callThrough();
-        documentTypes = getDocumentTypesProxy()({ '../utilities': utilitiesMock });
-    });
+    beforeAll(function() { spyOn(utilitiesMock, 'requestFun').and.callThrough(); });
     afterEach(function() { utilitiesMock.requestFun.calls.reset(); });
 
     describe('when initialised', function() {
         it('calls utilities.requestFun with constructor options', function() {
-            documentTypes(apiOptions);
+            documentTypes(apiOptions, utilitiesMock);
             expect(utilitiesMock.requestFun).toHaveBeenCalledWith(
-                jasmine.objectContaining(apiOptions)
+              jasmine.objectContaining(apiOptions)
             );
         });
 
         it('calls utilities.requestFun with correct request setup', function() {
-            documentTypes(apiOptions);
+            documentTypes(apiOptions, utilitiesMock);
             expect(utilitiesMock.requestFun).toHaveBeenCalledWith(
                 jasmine.objectContaining({
                     method: 'GET',
@@ -42,7 +29,7 @@ describe('documentTypes api', function() {
         });
 
         it('returns api object with "retrieve" property containing the request function', function() {
-            var documentTypesApi = documentTypes(apiOptions);
+            var documentTypesApi = documentTypes(apiOptions, utilitiesMock);
             expect(documentTypesApi.retrieve).toEqual(utilitiesMock.requestFun());
         });
     });

--- a/test/spec/api/document-types.spec.js
+++ b/test/spec/api/document-types.spec.js
@@ -6,7 +6,7 @@ var MIME_TYPES = require('../../../lib/mime-types');
 // fixtures
 var apiOptions = {
     baseUrl: 'https://api.mendeley.com',
-    authFlow: function() {},
+    authFlow: function() {}
 };
 
 // test globals

--- a/test/spec/api/search.spec.js
+++ b/test/spec/api/search.spec.js
@@ -3,35 +3,22 @@
 var utilitiesMock = require('../../mocks/utilities');
 var apiOptions = require('../../mocks/apiOptions');
 var MIME_TYPES = require('../../../lib/mime-types');
-
-// test globals
-var search;
-
-// server/browser aware dependency injection helper
-function getSearchProxy() {
-    return (typeof window !=='undefined') ?
-    require('proxy!../../../lib/api/search') :
-    require('proxyquire').bind(null, '../../../lib/api/search');
-}
+var search = require('../../../lib/api/search');
 
 describe('search api', function() {
-
-    beforeAll(function() {
-        spyOn(utilitiesMock, 'requestFun').and.callThrough();
-        search = getSearchProxy()({ '../utilities': utilitiesMock });
-    });
+    beforeAll(function() { spyOn(utilitiesMock, 'requestFun').and.callThrough(); });
     afterEach(function() { utilitiesMock.requestFun.calls.reset(); });
 
     describe('when initialised', function() {
         it('calls utilities.requestFun with constructor options', function() {
-            search(apiOptions);
+            search(apiOptions, utilitiesMock);
             expect(utilitiesMock.requestFun).toHaveBeenCalledWith(
                 jasmine.objectContaining(apiOptions)
             );
         });
 
         it('calls utilities.requestFun with correct request setup', function() {
-            search(apiOptions);
+            search(apiOptions, utilitiesMock);
             expect(utilitiesMock.requestFun).toHaveBeenCalledWith(
                 jasmine.objectContaining({
                     method: 'GET',
@@ -43,7 +30,7 @@ describe('search api', function() {
         });
 
         it('returns api object with "catalog" property containing the request function', function() {
-            var searchApi = search(apiOptions);
+            var searchApi = search(apiOptions, utilitiesMock);
             expect(searchApi.catalog).toEqual(utilitiesMock.requestFun());
         });
     });

--- a/test/spec/api/search.spec.js
+++ b/test/spec/api/search.spec.js
@@ -36,7 +36,8 @@ describe('search api', function() {
                 jasmine.objectContaining({
                     method: 'GET',
                     resource: '/search/catalog',
-                    headers: { 'Accept': MIME_TYPES.DOCUMENT }
+                    headers: { 'Accept': MIME_TYPES.DOCUMENT },
+                    responseFilter: utilitiesMock.paginationFilter
                 })
             );
         });

--- a/test/spec/api/search.spec.js
+++ b/test/spec/api/search.spec.js
@@ -6,7 +6,7 @@ var MIME_TYPES = require('../../../lib/mime-types');
 // fixtures
 var apiOptions = {
     baseUrl: 'https://api.mendeley.com',
-    authFlow: function() {},
+    authFlow: function() {}
 };
 
 // test globals

--- a/test/spec/api/search.spec.js
+++ b/test/spec/api/search.spec.js
@@ -1,17 +1,11 @@
 'use strict';
 
-var search = require('../../../lib/api/search');
+var utilitiesMock = require('../../mocks/utilities');
+var apiOptions = require('../../mocks/apiOptions');
 var MIME_TYPES = require('../../../lib/mime-types');
-
-// fixtures
-var apiOptions = {
-    baseUrl: 'https://api.mendeley.com',
-    authFlow: function() {}
-};
 
 // test globals
 var search;
-var requestFunSpy;
 
 // server/browser aware dependency injection helper
 function getSearchProxy() {
@@ -23,22 +17,22 @@ function getSearchProxy() {
 describe('search api', function() {
 
     beforeAll(function() {
-        requestFunSpy = jasmine.createSpy('requestFunSpy');
-        var utilitiesMock = { requestFun: requestFunSpy };
+        spyOn(utilitiesMock, 'requestFun').and.callThrough();
         search = getSearchProxy()({ '../utilities': utilitiesMock });
     });
+    afterEach(function() { utilitiesMock.requestFun.calls.reset(); });
 
     describe('when initialised', function() {
         it('calls utilities.requestFun with constructor options', function() {
             search(apiOptions);
-            expect(requestFunSpy).toHaveBeenCalledWith(
+            expect(utilitiesMock.requestFun).toHaveBeenCalledWith(
                 jasmine.objectContaining(apiOptions)
             );
         });
 
         it('calls utilities.requestFun with correct request setup', function() {
             search(apiOptions);
-            expect(requestFunSpy).toHaveBeenCalledWith(
+            expect(utilitiesMock.requestFun).toHaveBeenCalledWith(
                 jasmine.objectContaining({
                     method: 'GET',
                     resource: '/search/catalog',
@@ -47,9 +41,9 @@ describe('search api', function() {
             );
         });
 
-        it('returns api object with catalog search property', function() {
-            var searchApiMethods = Object.keys(search(apiOptions));
-            expect(searchApiMethods).toContain('catalog');
+        it('returns api object with "catalog" property containing the request function', function() {
+            var searchApi = search(apiOptions);
+            expect(searchApi.catalog).toEqual(utilitiesMock.requestFun());
         });
     });
 


### PR DESCRIPTION
This replaces an open pull request: https://github.com/Mendeley/mendeley-javascript-sdk/pull/98.

In the absence of the other PR's author I have decided to complete the previously requested PR changes and add paginationFilter to search.catalog endpoint.

@customcommander can you have a look at this next week? Thanks!