### PR TITLE
allow for sending FormData objects with new utility method

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -15,6 +15,7 @@ module.exports = {
     passFilter: passFilter,
     requestFun: requestFun,
     requestWithDataFun: requestWithDataFun,
+    requestWithRawDataFun: requestWithRawDataFun,
     requestWithFileFun: requestWithFileFun,
     paginationFilter:  pagination.filter
 };
@@ -135,6 +136,46 @@ function requestWithDataFun(options) {
             url: url,
             headers: getRequestHeaders(options.headers, data),
             data: JSON.stringify(data)
+        };
+
+        var settings = {
+            authFlow: options.authFlow(),
+            followLocation: options.followLocation
+        };
+
+        return Request.create(request, settings)
+            .send()
+            .then(options.responseFilter.bind(null, options));
+    };
+}
+
+/**
+ * Get a request function that sends data i.e. for POST, PUT, PATCH
+ * The data will be taken from the calling argument after any uriVar arguments.
+ *
+ * @private
+ * @param {function} [responseFilter] - Optional filter to control which part of the response the promise resolves with
+ * @param {string} method - The HTTP method
+ * @param {string} uriTemplate - A URI template e.g. /documents/{id}
+ * @param {array} uriVars - The variables for the URI template in the order
+ * they will be passed to the function e.g. ['id']
+ * @param {object} headers - Any additional headers to send
+ *  e.g. { 'Content-Type': 'application/vnd.mendeley-documents+1.json'}
+ * @param {bool} followLocation - follow the returned location header? Default is false
+ * @returns {function}
+ */
+function requestWithRawDataFun(options) {
+    options = normaliseOptions(options);
+
+    return function() {
+        var args = Array.prototype.slice.call(arguments, 0);
+        var url = getUrl(options, args);
+        var data = args[options.args.length];
+        var request = {
+            method: options.method,
+            url: url,
+            headers: getRequestHeaders(options.headers, data),
+            data: data
         };
 
         var settings = {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -15,7 +15,6 @@ module.exports = {
     passFilter: passFilter,
     requestFun: requestFun,
     requestWithDataFun: requestWithDataFun,
-    requestWithRawDataFun: requestWithRawDataFun,
     requestWithFileFun: requestWithFileFun,
     paginationFilter:  pagination.filter
 };
@@ -125,46 +124,6 @@ function requestFun(options) {
  * @returns {function}
  */
 function requestWithDataFun(options) {
-    options = normaliseOptions(options);
-
-    return function() {
-        var args = Array.prototype.slice.call(arguments, 0);
-        var url = getUrl(options, args);
-        var data = args[options.args.length];
-        var request = {
-            method: options.method,
-            url: url,
-            headers: getRequestHeaders(options.headers, data),
-            data: JSON.stringify(data)
-        };
-
-        var settings = {
-            authFlow: options.authFlow(),
-            followLocation: options.followLocation
-        };
-
-        return Request.create(request, settings)
-            .send()
-            .then(options.responseFilter.bind(null, options));
-    };
-}
-
-/**
- * Get a request function that sends data i.e. for POST, PUT, PATCH
- * The data will be taken from the calling argument after any uriVar arguments.
- *
- * @private
- * @param {function} [responseFilter] - Optional filter to control which part of the response the promise resolves with
- * @param {string} method - The HTTP method
- * @param {string} uriTemplate - A URI template e.g. /documents/{id}
- * @param {array} uriVars - The variables for the URI template in the order
- * they will be passed to the function e.g. ['id']
- * @param {object} headers - Any additional headers to send
- *  e.g. { 'Content-Type': 'application/vnd.mendeley-documents+1.json'}
- * @param {bool} followLocation - follow the returned location header? Default is false
- * @returns {function}
- */
-function requestWithRawDataFun(options) {
     options = normaliseOptions(options);
 
     return function() {

--- a/test/spec/api/annotations.spec.js
+++ b/test/spec/api/annotations.spec.js
@@ -93,11 +93,12 @@ describe('annotations api', function() {
 
     describe('create method', function() {
         var ajaxSpy, ajaxRequest;
+        var requestData = { document_id: 123, text: 'new annotation' };
 
         it('should be defined', function(done) {
             expect(typeof annotationsApi.create).toBe('function');
             ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            annotationsApi.create({document_id: 123, text: 'new annotation'}).finally(function() {
+            annotationsApi.create(requestData).finally(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
@@ -121,8 +122,8 @@ describe('annotations api', function() {
             expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
         });
 
-        it('should have a body of JSON string', function() {
-            expect(ajaxRequest.data).toBe('{"document_id":123,"text":"new annotation"}');
+        it('should pass request data in body', function() {
+            expect(ajaxRequest.data).toBe(requestData);
         });
 
     });
@@ -161,11 +162,12 @@ describe('annotations api', function() {
 
     describe('patch method', function() {
         var ajaxSpy, ajaxRequest;
+        var requestData = { text: 'updated annotation' };
 
         it('should be defined', function(done) {
             expect(typeof annotationsApi.patch).toBe('function');
             ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            annotationsApi.patch(123, {text: 'updated annotation'}).finally(function() {
+            annotationsApi.patch(123, requestData).finally(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
@@ -189,10 +191,9 @@ describe('annotations api', function() {
             expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
         });
 
-        it('should have a body of JSON', function() {
-            expect(ajaxRequest.data).toBe('{"text":"updated annotation"}');
+        it('should pass request data in body', function() {
+            expect(ajaxRequest.data).toBe(requestData);
         });
-
     });
 
     describe('pagination', function() {

--- a/test/spec/api/documents.spec.js
+++ b/test/spec/api/documents.spec.js
@@ -137,10 +137,11 @@ describe('documents api', function() {
             });
         });
 
-        it('should have a body of JSON string', function(done) {
-            documentsApi.create({ title: 'foo' }).finally(function() {
+        it('should pass request data in body', function(done) {
+            var requestData = { title: 'foo' };
+            documentsApi.create(requestData).finally(function() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
-                expect(ajaxRequest.data).toBe('{"title":"foo"}');
+                expect(ajaxRequest.data).toBe(requestData);
                 done();
             });
         });
@@ -332,11 +333,12 @@ describe('documents api', function() {
     describe('update method', function() {
 
         var ajaxRequest;
+        var requestData = { title: 'bar' };
 
         it('should be defined', function(done) {
             expect(typeof documentsApi.update).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseUpdate));
-            documentsApi.update(15, { title: 'bar' }).finally(function() {
+            documentsApi.update(15, requestData).finally(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
@@ -360,21 +362,21 @@ describe('documents api', function() {
             expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
         });
 
-        it('should have a body of JSON string', function() {
-            expect(ajaxRequest.data).toBe('{"title":"bar"}');
+        it('should pass request data in body', function() {
+            expect(ajaxRequest.data).toBe(requestData);
         });
-
     });
 
     describe('clone method', function() {
-
         var ajaxRequest,
             apiRequest;
+
+        var requestData = { 'group_id': 'bar' };
 
         it('should be defined', function(done) {
             expect(typeof documentsApi.clone).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseClone));
-            apiRequest = documentsApi.clone(15, { 'group_id': 'bar' }).finally(function() {
+            apiRequest = documentsApi.clone(15, requestData).finally(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
@@ -398,8 +400,8 @@ describe('documents api', function() {
             expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
         });
 
-        it('should have a body of JSON string', function() {
-            expect(ajaxRequest.data).toBe('{"group_id":"bar"}');
+        it('should pass request data in body', function() {
+            expect(ajaxRequest.data).toBe(requestData);
         });
 
         it('should resolve with the response', function(done) {

--- a/test/spec/api/folders.spec.js
+++ b/test/spec/api/folders.spec.js
@@ -83,10 +83,11 @@ describe('folders api', function() {
 
         });
 
-        it('should have a body of JSON string', function(done) {
-            foldersApi.create({ name: 'foo' }).finally(function() {
+        it('should pass request data in body', function(done) {
+            var requestData = { name: 'foo' };
+            foldersApi.create(requestData).finally(function() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
-                expect(ajaxRequest.data).toBe('{"name":"foo"}');
+                expect(ajaxRequest.data).toBe(requestData);
                 done();
             });
         });
@@ -193,10 +194,12 @@ describe('folders api', function() {
                 headers: {}
             });
         };
+        var requestData = { name: 'bar' };
+
         it('should be defined', function() {
             expect(typeof foldersApi.update).toBe('function');
             ajaxSpy = spyOn(axios, 'request').and.callFake(ajaxResponse);
-            foldersApi.update(123, { name: 'bar' });
+            foldersApi.update(123, requestData);
             expect(ajaxSpy).toHaveBeenCalled();
             ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
         });
@@ -218,10 +221,9 @@ describe('folders api', function() {
             expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
         });
 
-        it('should have a body of JSON string', function() {
-            expect(ajaxRequest.data).toBe('{"name":"bar"}');
+        it('should pass request data in body', function() {
+            expect(ajaxRequest.data).toBe(requestData);
         });
-
     });
 
     describe('list method', function() {

--- a/test/spec/api/followers.spec.js
+++ b/test/spec/api/followers.spec.js
@@ -46,8 +46,8 @@ describe('followers api', function() {
             expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
         });
 
-        it('should allow paramaters', function() {
-            expect(ajaxRequest.data).toEqual('{"followed":"c52e97f5-dd72-3cbe-a4cc-14bea2ed88f0"}');
+        it('should allow parameters', function() {
+            expect(ajaxRequest.data).toEqual(params);
         });
 
     });

--- a/test/spec/api/profiles.spec.js
+++ b/test/spec/api/profiles.spec.js
@@ -105,11 +105,12 @@ describe('profiles api', function() {
 
     describe('update method', function() {
         var ajaxRequest;
+        var requestData = { first_name: 'John', last_name: 'Doe' };
 
         it('should be defined', function(done) {
             expect(typeof profilesApi.update).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseUpdate));
-            profilesApi.update({first_name: 'John', last_name: 'Doe'}).finally(function() {
+            profilesApi.update(requestData).finally(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
@@ -133,10 +134,9 @@ describe('profiles api', function() {
             expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
         });
 
-        it('should have a body of JSON string', function() {
-            expect(ajaxRequest.data).toBe('{"first_name":"John","last_name":"Doe"}');
+        it('should pass request data in body', function() {
+            expect(ajaxRequest.data).toBe(requestData);
         });
-
     });
 
     describe('retrieve by email method', function() {

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -192,75 +192,6 @@ describe('utilities', function() {
                     Accept: 'mime/type1',
                     'Content-Type': 'mime/type2'
                 },
-                data: JSON.stringify(requestData)
-            }, {
-                authFlow: authFlow,
-                followLocation: true
-            });
-        });
-
-        it('should construct the url from supplied pattern and arguments', function() {
-            var requestFunction = utils.requestWithDataFun(assign({
-                method: 'POST',
-                resource: '/test/{first}/{second}',
-                args: ['first', 'second']
-            }, defaultOptions));
-
-            requestFunction(1, 2);
-
-            expect(requestCreateSpy).toHaveBeenCalledWith({
-                method: 'POST',
-                url: 'https://api.mendeley.com/test/1/2',
-                headers: {},
-                data: undefined
-            }, {
-                authFlow: authFlow,
-                followLocation: undefined
-            });
-        });
-
-        it('should allow properties to be filtered from the response using a responseFilter', function(done) {
-            var requestFunction = utils.requestWithDataFun(assign({
-                responseFilter: function(options, response) {
-                    return response.headers;
-                },
-                method: 'POST',
-                resource: '/test'
-            }, defaultOptions));
-
-            requestFunction().then(function(data) {
-                expect(data.Header).toBe('123');
-                done();
-            });
-        });
-
-    });
-
-    describe('requestWithRawDataFun', function() {
-
-        it('should create a request with given properties', function() {
-            var requestData = {
-                id: '123'
-            };
-            var requestFunction = utils.requestWithRawDataFun(assign({
-                method: 'POST',
-                resource: '/test',
-                headers: {
-                    Accept: 'mime/type1',
-                    'Content-Type': 'mime/type2'
-                },
-                followLocation: true
-            }, defaultOptions));
-
-            requestFunction(requestData);
-
-            expect(requestCreateSpy).toHaveBeenCalledWith({
-                method: 'POST',
-                url: 'https://api.mendeley.com/test',
-                headers: {
-                    Accept: 'mime/type1',
-                    'Content-Type': 'mime/type2'
-                },
                 data: requestData
             }, {
                 authFlow: authFlow,
@@ -269,7 +200,7 @@ describe('utilities', function() {
         });
 
         it('should construct the url from supplied pattern and arguments', function() {
-            var requestFunction = utils.requestWithRawDataFun(assign({
+            var requestFunction = utils.requestWithDataFun(assign({
                 method: 'POST',
                 resource: '/test/{first}/{second}',
                 args: ['first', 'second']
@@ -289,7 +220,7 @@ describe('utilities', function() {
         });
 
         it('should allow properties to be filtered from the response using a responseFilter', function(done) {
-            var requestFunction = utils.requestWithRawDataFun(assign({
+            var requestFunction = utils.requestWithDataFun(assign({
                 responseFilter: function(options, response) {
                     return response.headers;
                 },

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -236,6 +236,75 @@ describe('utilities', function() {
 
     });
 
+    describe('requestWithRawDataFun', function() {
+
+        it('should create a request with given properties', function() {
+            var requestData = {
+                id: '123'
+            };
+            var requestFunction = utils.requestWithRawDataFun(assign({
+                method: 'POST',
+                resource: '/test',
+                headers: {
+                    Accept: 'mime/type1',
+                    'Content-Type': 'mime/type2'
+                },
+                followLocation: true
+            }, defaultOptions));
+
+            requestFunction(requestData);
+
+            expect(requestCreateSpy).toHaveBeenCalledWith({
+                method: 'POST',
+                url: 'https://api.mendeley.com/test',
+                headers: {
+                    Accept: 'mime/type1',
+                    'Content-Type': 'mime/type2'
+                },
+                data: requestData
+            }, {
+                authFlow: authFlow,
+                followLocation: true
+            });
+        });
+
+        it('should construct the url from supplied pattern and arguments', function() {
+            var requestFunction = utils.requestWithRawDataFun(assign({
+                method: 'POST',
+                resource: '/test/{first}/{second}',
+                args: ['first', 'second']
+            }, defaultOptions));
+
+            requestFunction(1, 2);
+
+            expect(requestCreateSpy).toHaveBeenCalledWith({
+                method: 'POST',
+                url: 'https://api.mendeley.com/test/1/2',
+                headers: {},
+                data: undefined
+            }, {
+                authFlow: authFlow,
+                followLocation: undefined
+            });
+        });
+
+        it('should allow properties to be filtered from the response using a responseFilter', function(done) {
+            var requestFunction = utils.requestWithRawDataFun(assign({
+                responseFilter: function(options, response) {
+                    return response.headers;
+                },
+                method: 'POST',
+                resource: '/test'
+            }, defaultOptions));
+
+            requestFunction().then(function(data) {
+                expect(data.Header).toBe('123');
+                done();
+            });
+        });
+
+    });
+
     describe('requestWithFileFun', function() {
 
         var file = {


### PR DESCRIPTION
New method is exactly same as the original `requestWithDataFun` apart it doesn't automatically convert data to JSON. This will allow for using `FormData` objects and create `multipart/form-data` requests.