### PR TITLE
Passthrough option paramsSerializer for endpoints that have specific …

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -97,6 +97,11 @@ function requestFun(options) {
             settings.maxRetries = 1;
         }
 
+        // pass-through axios property for how querystring params are serialized.
+        if(options.paramsSerializer) {
+            request.paramsSerializer = options.paramsSerializer;
+        }
+
         return Request.create(request, settings)
             .send()
             .then(options.responseFilter.bind(null, options));

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -67,6 +67,29 @@ describe('utilities', function() {
             });
         });
 
+        it('should allow setting the paramsSerializer for different end points', function() {
+
+            var requestFunction = utils.requestFun(assign({
+                method: 'GET',
+                resource: '/test/',
+                paramsSerializer: 'injected_paramsSerializer'
+            }, defaultOptions));
+
+            requestFunction();
+
+            expect(requestCreateSpy).toHaveBeenCalledWith({
+                method: 'GET',
+                responseType: 'json',
+                url: 'https://api.mendeley.com/test/',
+                headers: {},
+                params: undefined,
+                paramsSerializer: 'injected_paramsSerializer'
+            }, {
+                authFlow: authFlow,
+                maxRetries: 1
+            });
+        });
+
         it('should construct the url from supplied pattern and arguments', function() {
             var requestFunction = utils.requestFun(assign({
                 method: 'GET',


### PR DESCRIPTION
…array parameter format requirements.

Default configuration for axios is called "Brackets".
This takes parameter array and converts it to querystring as: 

`{ roles: ["one", "two"] } -> ?roles[]=one&roles[]=two`

Group membership endpoint requires params in the format: 

`{ roles: ["one", "two"] }  -> roles=one&roles=two` 

This PR allows the end point configuration to pass in the paramsSerializer required.

