### PR TITLE
Remove Bluebird dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Depending on your target browsers, you may need to polyfill Promise because the 
 ```
 {
     plugins: [new webpack.ProvidePlugin({
-        Promise: 'bluebird'
+        Promise: 'es6-promise'
     })];
 }
 ```
@@ -195,7 +195,7 @@ Once the OAuth flow is complete you can start grabbing data for the user. CORS i
 
 Each API is exposed as a property of the SDK, for example `api.documents`, `api.folders`.
 
-Methods that make API calls return [Bluebird promises][]. Each call will either resolve with some data or reject with a response object according to the response from [axios][]. Here's an example using the standalone version:
+Methods that make API calls return [ES6 Promises][]. Each call will either resolve with some data or reject with a response object according to the response from [axios][]. Here's an example using the standalone version:
 
 ```javascript
 api.documents.list().then(function(docs) {
@@ -365,7 +365,7 @@ If you make changes please check coverage reports under `/coverage` to make sure
 Please note the aim of this SDK is to connect to the existing Mendeley API, not to add to that API. For more information about the API and to give any feedback please visit [the Mendeley developers site].
 
 
-[Bluebird promises]:http://bluebirdjs.com/docs/api-reference.html
+[ES6 Promises]:https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
 [axios]:https://github.com/mzabriskie/axios#response-schema
 [es5-shim]:https://github.com/es-shims/es5-shim
 [browserify]:http://browserify.org/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Depending on your target browsers, you may need to polyfill Promise because the 
 ```
 {
     plugins: [new webpack.ProvidePlugin({
-        Promise: 'es6-promise'
+        Promise: 'es6-promise-promise'
     })];
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Depending on your target browsers, you may need to polyfill Promise because the 
 }
 ```
 
+Alternatively, you can pass your own Promise implementation at runtime:
+
+```js
+var sdk = require('@mendeley/api').withPromise(require('bluebird'));
+```
+
 Some ECMAScript5 features are used so for older browsers you may need to shim these methods, for example with [es5-shim][].
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -177,3 +177,15 @@ https://github.com/mzabriskie/axios#global-axios-defaults
 ## Upgrading to v7.x
 
 1. Removes legacy `JSON.stringify` of request data as Axios handles this natively. This should be backwards compatible, but making a major release as could break user's unit tests if they attempt to extend the built-in Request object.
+
+## Upgrading to v8.x
+
+1. Removes the implicit Bluebird dependency. Bluebird, or any Promises/A+ implementation, can be provided to this SDK and all methods that previously returned a Bluebird promise will now return an instance of the implemention explicitly provided. For example:
+
+  ```javascript
+  // old
+  var api = require('@mendeley/api');
+  
+  // new
+  var api = require('@mendeley/api').withPromise(require('bluebird'));
+  ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,7 +20,7 @@ or .always() - you must use .then(), .catch(), and .finally()
     ```javascript
     spyOn(api.documents, 'create').and.returnValue($.Deferred().resolve());
     // becomes
-    spyOn(api.documents, 'create').and.returnValue(Bluebird.resolve());
+    spyOn(api.documents, 'create').and.returnValue(Promise.resolve());
     ```
 
 1. The .then() success handler now only gets one parameter - the data returned by
@@ -33,7 +33,7 @@ For projects using Webpack, include the following plugin in your config:
     ```javascript
     {
         plugins: [new webpack.ProvidePlugin({
-            Promise: 'bluebird'
+            Promise: 'es6-promise-promise'
         })];
     }
     ```

--- a/examples/oauth-app.js
+++ b/examples/oauth-app.js
@@ -11,7 +11,6 @@ module.exports = function(app, config) {
 
     var cookieParser = require('cookie-parser');
     var sdk = require('../lib/api');
-    var Bluebird = require('bluebird');
     var accessTokenCookieName = 'accessToken';
     var refreshTokenCookieName = 'refreshToken';
     var examplesPath = '/examples';
@@ -115,9 +114,9 @@ module.exports = function(app, config) {
 
             refreshToken: function() {
                 if (!refreshToken) {
-                    return Bluebird.reject(new Error('No refresh token'));
+                    return Promise.reject(new Error('No refresh token'));
                 } else {
-                    return new Bluebird(function(resolve, reject) {
+                    return new Promise(function(resolve, reject) {
                         oauth2.accessToken.create({
                             access_token: accessToken,
                             refresh_token: refreshToken
@@ -153,7 +152,7 @@ module.exports = function(app, config) {
 
             refreshToken: function() {
                 console.log('Refreshing token');
-                return new Bluebird(function(resolve, reject) {
+                return new Promise(function(resolve, reject) {
                     oauth2.client.getToken({
                         scope: 'all'
                     }, function(error, token) {

--- a/examples/oauth-app.js
+++ b/examples/oauth-app.js
@@ -11,6 +11,7 @@ module.exports = function(app, config) {
 
     var cookieParser = require('cookie-parser');
     var sdk = require('../lib/api');
+    var Promise = require('../lib/promise-proxy');
     var accessTokenCookieName = 'accessToken';
     var refreshTokenCookieName = 'refreshToken';
     var examplesPath = '/examples';

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,8 @@
 // Karma configuration
 // Generated on Fri Sep 12 2014 15:16:30 GMT+0100 (BST)
 
+var webpack = require('webpack');
+
 module.exports = function(config) {
 
     'use strict';
@@ -67,7 +69,10 @@ module.exports = function(config) {
         // if true, Karma captures browsers, runs the tests and exits
         singleRun: false,
 
-        webpack: require(process.cwd() + '/webpack.config'),
+        webpack: Object.assign( {},
+                     require(process.cwd() + '/webpack.config'),
+                     { plugins: [new webpack.ProvidePlugin({ Promise: 'bluebird' })] }
+                 ),
 
         // Prevents webpack from logging stats on all the chunks
         webpackMiddleware: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -71,7 +71,7 @@ module.exports = function(config) {
 
         webpack: Object.assign( {},
                      require(process.cwd() + '/webpack.config'),
-                     { plugins: [new webpack.ProvidePlugin({ Promise: 'bluebird' })] }
+                     { plugins: [new webpack.ProvidePlugin({ Promise: 'es6-promise-promise' })] }
                  ),
 
         // Prevents webpack from logging stats on all the chunks

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,13 +1,7 @@
 'use strict';
 
 var assign = require('object-assign');
-var Bluebird = require('bluebird');
 var utils = require('./utilities');
-
-Bluebird.config({
-    warnings: false,
-    wForgottenReturn: false
-});
 
 try {
     // prevent crashing in node-like environments

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var api = require('./api');
 var auth = require('./auth');
 var request = require('./request');
 var mimeTypes = require('./mime-types');
+var PromiseProxy = require('./promise-proxy');
 
 // Exports Mendeley SDK
 module.exports = function (options) {
@@ -36,3 +37,17 @@ module.exports = function (options) {
 module.exports.Auth = auth;
 module.exports.Request = request;
 module.exports.MimeTypes = mimeTypes;
+
+/**
+ * Allows a custom Promise library to be used.
+ * The method is chainable to allow ease of use when importing, for example:
+ * 
+ * var api = require('@mendeley/api').withPromise(require('bluebird'));
+ * 
+ * @param {Promise} customPromise
+ * @returns {function}
+ */
+module.exports.withPromise = function(customPromise) {
+  PromiseProxy.setPromise(customPromise);
+  return module.exports;
+};

--- a/lib/promise-proxy.js
+++ b/lib/promise-proxy.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var CustomPromise = Promise;
+
+/**
+ * An ES2015-compliant Promise proxy.
+ * Allows the underlying reference to `Promise` to change after this library has been initialised and all modules hold a reference to it.
+ * Instance methods, `then` and `catch`, need not be proxied as an instance of PromiseProxy is never created.
+ *
+ * @class
+ * @name PromiseProxy
+ */
+module.exports = PromiseProxy;
+
+// constructor (proxy)
+function PromiseProxy(executor) {
+    return new CustomPromise(executor);
+}
+
+// static methods
+PromiseProxy.setPromise = function(customPromise) {
+    CustomPromise = customPromise;
+}
+
+// static methods (proxy)
+PromiseProxy.all = function() {
+    return CustomPromise.all.apply(CustomPromise, arguments);
+}
+PromiseProxy.race = function() {
+    return CustomPromise.race.apply(CustomPromise, arguments);
+}
+PromiseProxy.reject = function() {
+    return CustomPromise.reject.apply(CustomPromise, arguments);
+}
+PromiseProxy.resolve = function() {
+    return CustomPromise.resolve.apply(CustomPromise, arguments);
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,6 +2,7 @@
 
 var axios = require('axios');
 var assign = require('object-assign');
+var Promise = require('./promise-proxy');
 
 var defaults = {
     authFlow: false,

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,7 +2,6 @@
 
 var axios = require('axios');
 var assign = require('object-assign');
-var Bluebird = require('bluebird');
 
 var defaults = {
     authFlow: false,
@@ -159,7 +158,7 @@ function refreshToken() {
         return promise;
     } else {
         this.settings.authFlow.authenticate();
-        return Bluebird.reject(new Error('No token'));
+        return Promise.reject(new Error('No token'));
     }
 }
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -2,7 +2,6 @@
 
 var Request = require('./request');
 var assign = require('object-assign');
-var Bluebird = require('bluebird');
 var pagination = require('./pagination');
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendeley/api",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "description": "Mendeley API JavaScript SDK",
   "directories": {
     "example": "examples"

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "bluebird": "^3.4.0",
     "bower": "^1.7.2",
     "cookie-parser": "^1.3.3",
     "es5-shim": "^4.5.9",
+    "es6-promise-promise": "^1.0.0",
     "express": "^4.9.5",
     "jasmine": "^2.4.1",
     "jsdoc": "^3.3.0-alpha9",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
+    "bluebird": "^3.4.0",
     "bower": "^1.7.2",
     "cookie-parser": "^1.3.3",
     "es5-shim": "^4.5.9",
@@ -54,7 +55,6 @@
   },
   "dependencies": {
     "axios": "^0.14.0",
-    "bluebird": "^3.4.0",
     "form-urlencoded": "^1.4.1",
     "object-assign": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendeley/api",
-  "version": "8.0.0",
+  "version": "7.2.0",
   "description": "Mendeley API JavaScript SDK",
   "directories": {
     "example": "examples"

--- a/test/mocks/auth.js
+++ b/test/mocks/auth.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Promise = require('../../lib/promise-proxy');
+
 var unauthorisedError = new Error();
 unauthorisedError.response = { status: 401 };
 

--- a/test/mocks/auth.js
+++ b/test/mocks/auth.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Bluebird = require('bluebird');
-
 var unauthorisedError = new Error();
 unauthorisedError.response = { status: 401 };
 
@@ -42,7 +40,7 @@ function mockAuthCodeFlow() {
         authenticate: function() { throw new Error('Cannot authenticate'); },
         refreshToken: function() {
             fakeToken = 'auth-refreshed';
-            return Bluebird.resolve();
+            return Promise.resolve();
         }
     };
 }
@@ -55,7 +53,7 @@ function slowAuthCodeFlow() {
       getToken: function() { return fakeToken; },
       authenticate: function() {},
       refreshToken: function() {
-          return new Bluebird(function (resolve) {
+          return new Promise(function (resolve) {
               setTimeout(function () {
                   refreshCount++;
                   fakeToken = 'auth-refreshed-' + refreshCount;

--- a/test/spec/api/annotations.spec.js
+++ b/test/spec/api/annotations.spec.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -23,13 +22,15 @@ describe('annotations api', function() {
 
         it('be defined', function(done) {
             expect(typeof annotationsApi.list).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
-            annotationsApi.list(params).finally(function() {
+            annotationsApi.list(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -61,12 +62,14 @@ describe('annotations api', function() {
 
         it('should be defined', function(done) {
             expect(typeof annotationsApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            annotationsApi.retrieve(123).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            annotationsApi.retrieve(123).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -97,12 +100,14 @@ describe('annotations api', function() {
 
         it('should be defined', function(done) {
             expect(typeof annotationsApi.create).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            annotationsApi.create(requestData).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            annotationsApi.create(requestData).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use POST', function() {
@@ -133,12 +138,14 @@ describe('annotations api', function() {
 
         it('should be defined', function(done) {
             expect(typeof annotationsApi.delete).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            annotationsApi.delete(123).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            annotationsApi.delete(123).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use DELETE', function() {
@@ -166,12 +173,14 @@ describe('annotations api', function() {
 
         it('should be defined', function(done) {
             expect(typeof annotationsApi.patch).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            annotationsApi.patch(123, requestData).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            annotationsApi.patch(123, requestData).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use PATCH', function() {
@@ -203,7 +212,7 @@ describe('annotations api', function() {
         var linkLast = baseUrl + '/annotations/?limit=5&reverse=true';
 
         function ajaxSpy() {
-            return spyOn(axios, 'request').and.returnValue(Bluebird.resolve({
+            return spyOn(axios, 'request').and.returnValue(Promise.resolve({
                 headers: {
                     link: '<' + linkNext + '>; rel="next",<' + linkLast + '>; rel="last",<' + linkFirst + '>; rel="first"',
                     'mendeley-count': 56
@@ -229,10 +238,12 @@ describe('annotations api', function() {
             annotationsApi.list().then(function(page) {
                 return page.next();
             })
-            .finally(function() {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
                 done();
-            });
+            }
         });
 
         it('should get correct link on lastPage()', function(done) {
@@ -241,10 +252,12 @@ describe('annotations api', function() {
             annotationsApi.list().then(function(page) {
                 return page.last();
             })
-            .finally(function() {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
                 done();
-            });
+            }
         });
 
         it('should store the total document count', function(done) {

--- a/test/spec/api/annotations.spec.js
+++ b/test/spec/api/annotations.spec.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/catalog.spec.js
+++ b/test/spec/api/catalog.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -21,12 +20,14 @@ describe('catalog api', function() {
 
         it('should be defined', function(done) {
             expect(typeof catalogApi.search).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            catalogApi.search(params).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            catalogApi.search(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -61,12 +62,14 @@ describe('catalog api', function() {
 
         it('should be defined', function(done) {
             expect(typeof catalogApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            catalogApi.retrieve('catalogId', params).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            catalogApi.retrieve('catalogId', params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {

--- a/test/spec/api/documents.spec.js
+++ b/test/spec/api/documents.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -20,7 +19,7 @@ describe('documents api', function() {
     }).documents;
 
     // Mock ajax response promises
-    var mockPromiseCreate = Bluebird.resolve({
+    var mockPromiseCreate = Promise.resolve({
         data: '',
         status: 201,
         headers: {
@@ -28,13 +27,13 @@ describe('documents api', function() {
         }
     });
 
-    var mockPromiseRetrieve = Bluebird.resolve({
+    var mockPromiseRetrieve = Promise.resolve({
         data: { id: '15', title: 'foo' },
         status: 200,
         headers: {}
     });
 
-    var mockPromiseCreateFromFile = Bluebird.resolve({
+    var mockPromiseCreateFromFile = Promise.resolve({
         data: { id: '15', title: 'foo' },
         status: 201,
         headers: {
@@ -42,7 +41,7 @@ describe('documents api', function() {
         }
     });
 
-    var mockPromiseUpdate = Bluebird.resolve({
+    var mockPromiseUpdate = Promise.resolve({
         data: { id: '15', title: 'foo' },
         status: 200,
         headers: {
@@ -50,7 +49,7 @@ describe('documents api', function() {
         }
     });
 
-    var mockPromiseClone = Bluebird.resolve({
+    var mockPromiseClone = Promise.resolve({
         data: {  id: '16', title: 'foo', 'group_id': 'bar' },
         status: 200,
         headers: {
@@ -58,7 +57,7 @@ describe('documents api', function() {
         }
     });
 
-    var mockPromiseList = Bluebird.resolve({
+    var mockPromiseList = Promise.resolve({
         data: [{ id: '15', title: 'foo' }],
         status: 200,
         headers: {
@@ -66,7 +65,7 @@ describe('documents api', function() {
         }
     });
 
-    var mockPromiseTrash = Bluebird.resolve({
+    var mockPromiseTrash = Promise.resolve({
         data: null,
         status: 204,
         headers: {
@@ -74,9 +73,9 @@ describe('documents api', function() {
         }
     });
 
-    var mockPromiseNotFound = Bluebird.reject({ response: { status: 404 } });
+    var mockPromiseNotFound = Promise.reject({ response: { status: 404 } });
 
-    var mockPromiseInternalError = Bluebird.reject({ response: { status: 500 } });
+    var mockPromiseInternalError = Promise.reject({ response: { status: 500 } });
 
     // Get a function to return promises in order
     function getMockPromises() {
@@ -98,62 +97,76 @@ describe('documents api', function() {
 
         it('should be defined', function(done) {
             expect(typeof documentsApi.create).toBe('function');
-            documentsApi.create({ title: 'foo' }).finally(function() {
+            documentsApi.create({ title: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 done();
-            });
+            }
         });
 
         it('should use POST', function(done) {
-            documentsApi.create({ title: 'foo' }).finally(function() {
+            documentsApi.create({ title: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.method).toBe('post');
                 done();
-            });
+            }
         });
 
         it('should use endpoint /documents', function(done) {
-            documentsApi.create({ title: 'foo' }).finally(function() {
+            documentsApi.create({ title: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.url).toBe(baseUrl + '/documents');
                 done();
-            });
+            }
         });
 
         it('should have a Content-Type header', function(done) {
-            documentsApi.create({ title: 'foo' }).finally(function() {
+            documentsApi.create({ title: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.headers['Content-Type']).toBeDefined();
                 done();
-            });
+            }
         });
 
         it('should have an Authorization header', function(done) {
-            documentsApi.create({ title: 'foo' }).finally(function() {
+            documentsApi.create({ title: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.headers.Authorization).toBeDefined();
                 expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
                 done();
-            });
+            }
         });
 
         it('should pass request data in body', function(done) {
             var requestData = { title: 'foo' };
-            documentsApi.create(requestData).finally(function() {
+            documentsApi.create(requestData).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.data).toBe(requestData);
                 done();
-            });
+            }
         });
 
         it('should follow Location header', function(done) {
-            documentsApi.create({ title: 'foo' }).finally(function() {
+            documentsApi.create({ title: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 var ajaxRedirect = ajaxSpy.calls.mostRecent().args[0];
                 expect(ajaxRedirect.method).toBe('get');
                 expect(ajaxRedirect.url).toBe(baseUrl + '/documents/123');
                 done();
-            });
+            }
         });
 
         it('should resolve with the response', function(done) {
@@ -195,60 +208,74 @@ describe('documents api', function() {
 
         it('should be defined', function(done) {
             expect(typeof documentsApi.createFromFile).toBe('function');
-            documentsApi.createFromFile(file).finally(function() {
+            documentsApi.createFromFile(file).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 done();
-            });
+            }
         });
 
         it('should use POST', function(done) {
-            documentsApi.createFromFile(file).finally(function() {
+            documentsApi.createFromFile(file).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.method).toBe('post');
                 done();
-            });
+            }
         });
 
         it('should use endpoint /documents', function(done) {
-            documentsApi.createFromFile(file).finally(function() {
+            documentsApi.createFromFile(file).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.url).toBe(baseUrl + '/documents');
                 done();
-            });
+            }
         });
 
         it('should have a Content-Type header the same as the file', function(done) {
-            documentsApi.createFromFile(file).finally(function() {
+            documentsApi.createFromFile(file).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.headers['Content-Type']).toBeDefined();
                 expect(ajaxRequest.headers['Content-Type']).toEqual('text/plain');
                 done();
-            });
+            }
         });
 
         it('should have a Content-Disposition header based on file name', function(done) {
-            documentsApi.createFromFile(file).finally(function() {
+            documentsApi.createFromFile(file).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.headers['Content-Disposition']).toEqual('attachment; filename*=UTF-8\'\'%E4%B8%AD%E6%96%87file%20name%281%29.pdf');
                 done();
-            });
+            }
         });
 
         it('should have an Authorization header', function(done) {
-            documentsApi.createFromFile(file).finally(function() {
+            documentsApi.createFromFile(file).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.headers.Authorization).toBeDefined();
                 expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
                 done();
-            });
+            }
         });
 
         it('should have a body of the file contents', function(done) {
-            documentsApi.createFromFile(file).finally(function() {
+            documentsApi.createFromFile(file).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.data).toEqual(file);
                 done();
-            });
+            }
         });
 
         it('should resolve with the response', function(done) {
@@ -269,11 +296,13 @@ describe('documents api', function() {
         it('should be defined', function(done) {
             expect(typeof documentsApi.createFromFile).toBe('function');
             ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseCreateFromFile));
-            apiRequest = documentsApi.createFromFileInGroup(file, 123).finally(function() {
+            apiRequest = documentsApi.createFromFileInGroup(file, 123).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 done();
-            });
+            }
         });
 
         it('should have a Link header', function() {
@@ -288,11 +317,13 @@ describe('documents api', function() {
         it('should be defined', function(done) {
             expect(typeof documentsApi.retrieve).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseRetrieve));
-            documentsApi.retrieve(15).finally(function() {
+            documentsApi.retrieve(15).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -338,11 +369,13 @@ describe('documents api', function() {
         it('should be defined', function(done) {
             expect(typeof documentsApi.update).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseUpdate));
-            documentsApi.update(15, requestData).finally(function() {
+            documentsApi.update(15, requestData).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use PATCH', function() {
@@ -376,11 +409,14 @@ describe('documents api', function() {
         it('should be defined', function(done) {
             expect(typeof documentsApi.clone).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseClone));
-            apiRequest = documentsApi.clone(15, requestData).finally(function() {
+            apiRequest = documentsApi.clone(15, requestData).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+                return arguments[0];
+            }
         });
 
         it('should use POST', function() {
@@ -425,11 +461,13 @@ describe('documents api', function() {
             expect(typeof documentsApi.list).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseList));
 
-            documentsApi.list(params).finally(function() {
+            documentsApi.list(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -467,11 +505,13 @@ describe('documents api', function() {
 
         it('should use the folders API', function(done) {
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseList));
-            documentsApi.list(params).finally(function() {
+            documentsApi.list(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -495,11 +535,13 @@ describe('documents api', function() {
         it('should be defined', function(done) {
             expect(typeof documentsApi.trash).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseTrash));
-            documentsApi.trash(15).finally(function() {
+            documentsApi.trash(15).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use POST', function() {
@@ -526,7 +568,7 @@ describe('documents api', function() {
         var ajaxSpy;
 
         it('should retry on 504', function(done) {
-            ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(Bluebird.reject({ response: { status: 504 } }), mockPromiseList));
+            ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(Promise.reject({ response: { status: 504 } }), mockPromiseList));
             documentsApi.list().then(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 expect(ajaxSpy.calls.count()).toBe(2);
@@ -535,7 +577,7 @@ describe('documents api', function() {
         });
 
         it('should only retry once', function(done) {
-            ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(Bluebird.reject({ response: { status: 504 } }), Bluebird.reject({ response: { status: 504 } }), mockPromiseList));
+            ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(Promise.reject({ response: { status: 504 } }), Promise.reject({ response: { status: 504 } }), mockPromiseList));
             documentsApi.list().catch(function() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 expect(ajaxSpy.calls.count()).toBe(2);
@@ -583,7 +625,7 @@ describe('documents api', function() {
                 headers.link = ['<' + linkNext + '>; rel="next"', '<' + linkPrev + '>; rel="previous"', '<' + linkLast + '>; rel="last"'].join(', ');
             }
 
-            spy.and.returnValue(Bluebird.resolve({
+            spy.and.returnValue(Promise.resolve({
                 headers: headers
             }));
             axios.request = spy;
@@ -610,10 +652,12 @@ describe('documents api', function() {
             .then(function(page) {
                 return page.next();
             })
-            .finally(function () {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
                 done();
-            });
+            }
         });
 
         it('should get correct link on previous()', function(done) {
@@ -623,10 +667,12 @@ describe('documents api', function() {
             .then(function(page) {
                 return page.previous();
             })
-            .finally(function () {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkPrev);
                 done();
-            });
+            }
         });
 
         it('should get correct link on lastPage()', function(done) {
@@ -636,10 +682,12 @@ describe('documents api', function() {
             .then(function(page) {
                 return page.last();
             })
-            .finally(function () {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
                 done();
-            });
+            }
         });
 
         it('should store the total document count', function(done) {

--- a/test/spec/api/files.spec.js
+++ b/test/spec/api/files.spec.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -30,7 +29,7 @@ describe('files api', function() {
             var fileResource = {
                 url: 'http://mendeley.cdn.com/123'
             };
-            return Bluebird.resolve({
+            return Promise.resolve({
                 data: fileResource,
                 status: 201,
                 headers: {}
@@ -42,11 +41,13 @@ describe('files api', function() {
         it('should be defined', function(done) {
             expect(typeof filesApi.create).toBe('function');
             ajaxSpy = spyOn(axios, 'request').and.callFake(ajaxResponse);
-            filesApi.create(file, 123).finally(function() {
+            filesApi.create(file, 123).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 done();
-            });
+            }
 
         });
 
@@ -86,11 +87,13 @@ describe('files api', function() {
             var typelessFile = getFakeFile('filename.pdf', '');
             ajaxSpy = spyOn(axios, 'request').and.callFake(ajaxResponse);
 
-            filesApi.create(123, typelessFile).finally(function() {
+            filesApi.create(123, typelessFile).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.headers['Content-Type']).toEqual('application/octet-stream');
                 done();
-            });
+            }
         });
     });
 
@@ -105,13 +108,16 @@ describe('files api', function() {
 
         it('be defined', function(done) {
             expect(typeof filesApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve(sampleResponse));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve(sampleResponse));
 
-            responsePromise = filesApi.retrieve('someId').finally(function() {
+            responsePromise = filesApi.retrieve('someId').then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+                return arguments[0];
+            }
         });
 
         it('should use GET', function() {
@@ -144,7 +150,7 @@ describe('files api', function() {
 
         it('should not follow HTTP redirects', function() {
             expect(typeof filesApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
             filesApi.retrieve('someId');
 
             var requestArgs = ajaxSpy.calls.first().args[0];
@@ -154,7 +160,7 @@ describe('files api', function() {
 
         it('should handle HTTP redirects like successful response', function() {
             expect(typeof filesApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
             filesApi.retrieve('someId');
 
             var requestArgs = ajaxSpy.calls.first().args[0];
@@ -171,12 +177,14 @@ describe('files api', function() {
 
         it('be defined', function(done) {
             expect(typeof filesApi.list).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            filesApi.list('someId').finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            filesApi.list('someId').then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -213,12 +221,15 @@ describe('files api', function() {
 
         it('be defined', function(done) {
             expect(typeof filesApi.remove).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            filesApi.remove('fileId').finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            filesApi.remove('fileId').then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+                return arguments[0];
+            }
         });
 
         it('should use DELETE', function() {

--- a/test/spec/api/files.spec.js
+++ b/test/spec/api/files.spec.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/folders.spec.js
+++ b/test/spec/api/folders.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/folders.spec.js
+++ b/test/spec/api/folders.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -20,14 +19,14 @@ describe('folders api', function() {
         var ajaxCalls = 0;
         var ajaxResponse = function() {
             if (ajaxCalls++ % 2 === 0) {
-                return Bluebird.resolve({
+                return Promise.resolve({
                     status: 201,
                     headers: {
                         location: baseUrl + '/folders/123'
                     }
                 });
             } else {
-                return Bluebird.resolve({
+                return Promise.resolve({
                     status: 200,
                     data: { id: '123', name: 'foo' },
                     headers: {}
@@ -41,64 +40,75 @@ describe('folders api', function() {
 
         it('should be defined', function(done) {
             expect(typeof foldersApi.create).toBe('function');
-            foldersApi.create({ name: 'foo' }).finally(function() {
+            foldersApi.create({ name: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 done();
-            });
+            }
         });
 
         it('should use POST', function(done) {
-            foldersApi.create({ name: 'foo' }).finally(function() {
+            foldersApi.create({ name: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.method).toBe('post');
                 done();
-            });
+            }
         });
 
         it('should use endpoint /folders', function(done) {
-            foldersApi.create({ name: 'foo' }).finally(function() {
+            foldersApi.create({ name: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.url).toBe(baseUrl + '/folders');
                 done();
-            });
-
+            }
         });
 
         it('should have a Content-Type header', function(done) {
-            foldersApi.create({ name: 'foo' }).finally(function() {
+            foldersApi.create({ name: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.headers['Content-Type']).toBeDefined();
                 done();
-            });
-
+            }
         });
 
         it('should have an Authorization header', function(done) {
-            foldersApi.create({ name: 'foo' }).finally(function() {
+            foldersApi.create({ name: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.headers.Authorization).toBeDefined();
                 expect(ajaxRequest.headers.Authorization).toBe('Bearer auth');
                 done();
-            });
-
+            }
         });
 
         it('should pass request data in body', function(done) {
             var requestData = { name: 'foo' };
-            foldersApi.create(requestData).finally(function() {
+            foldersApi.create(requestData).then(_finally, _finally);
+
+            function _finally() {
                 ajaxRequest = ajaxSpy.calls.first().args[0];
                 expect(ajaxRequest.data).toBe(requestData);
                 done();
-            });
+            }
         });
 
         it('should follow Location header', function(done) {
-            foldersApi.create({ name: 'foo' }).finally(function() {
+            foldersApi.create({ name: 'foo' }).then(_finally, _finally);
+
+            function _finally() {
                 var ajaxRedirect = ajaxSpy.calls.mostRecent().args[0];
                 expect(ajaxRedirect.method).toBe('get');
                 expect(ajaxRedirect.url).toBe(baseUrl + '/folders/123');
                 done();
-            });
+            }
         });
 
         it('should resolve with the data', function(done) {
@@ -113,7 +123,7 @@ describe('folders api', function() {
 
         it('should reject create errors with the response', function(done) {
             var ajaxFailureResponse = function() {
-                return Bluebird.reject({ response: { status: 500 } });
+                return Promise.reject({ response: { status: 500 } });
             };
             spyOn(axios, 'request').and.callFake(ajaxFailureResponse);
             foldersApi.create({ name: 'foo' }).catch(function(error) {
@@ -127,7 +137,7 @@ describe('folders api', function() {
             var ajaxMixedResponse = function() {
                 // First call apparently works and returns location
                 if (ajaxMixedCalls++ === 0) {
-                    return Bluebird.resolve({
+                    return Promise.resolve({
                         headers: {
                             location: baseUrl + '/folders/123'
                         },
@@ -136,7 +146,7 @@ describe('folders api', function() {
                 }
                 // But following the location fails
                 else {
-                    return Bluebird.reject({ response: { status: 404 } });
+                    return Promise.reject({ response: { status: 404 } });
                 }
             };
             spyOn(axios, 'request').and.callFake(ajaxMixedResponse);
@@ -154,7 +164,7 @@ describe('folders api', function() {
 
         it('should be defined', function() {
             expect(typeof foldersApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
             foldersApi.retrieve(123);
             expect(ajaxSpy).toHaveBeenCalled();
             ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
@@ -189,7 +199,7 @@ describe('folders api', function() {
         var ajaxSpy;
         var ajaxRequest;
         var ajaxResponse = function() {
-            return Bluebird.resolve({
+            return Promise.resolve({
                 data: { id: '123', name: 'bar' },
                 headers: {}
             });
@@ -236,7 +246,7 @@ describe('folders api', function() {
 
         it('be defined', function() {
             expect(typeof foldersApi.list).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
             foldersApi.list(params);
             expect(ajaxSpy).toHaveBeenCalled();
@@ -286,7 +296,7 @@ describe('folders api', function() {
                 headers.link = ['<' + linkNext + '>; rel="next"', '<' + linkLast + '>; rel="last"'].join(', ');
             }
 
-            spy.and.returnValue(Bluebird.resolve({
+            spy.and.returnValue(Promise.resolve({
                 data: [],
                 headers: headers
             }));
@@ -315,10 +325,12 @@ describe('folders api', function() {
             .then(function (page) {
                 return page.next();
             })
-            .finally(function () {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
                 done();
-            });
+            }
         });
 
         it('should get correct link on last()', function(done) {
@@ -328,10 +340,12 @@ describe('folders api', function() {
             .then(function (page) {
                 return page.last();
             })
-            .finally(function () {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
                 done();
-            });
+            }
         });
 
         it('should store the total document count', function(done) {

--- a/test/spec/api/followers.spec.js
+++ b/test/spec/api/followers.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/followers.spec.js
+++ b/test/spec/api/followers.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -21,12 +20,14 @@ describe('followers api', function() {
 
         it('should be defined', function(done) {
             expect(typeof followersApi.create).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            followersApi.create(params).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            followersApi.create(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use POST', function() {
@@ -61,13 +62,15 @@ describe('followers api', function() {
 
         it('should be defined', function(done) {
             expect(typeof followersApi.list).toBe('function');
-            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
-            followersApi.list(params).finally(function() {
+            followersApi.list(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -99,13 +102,15 @@ describe('followers api', function() {
 
         it('should be defined', function(done) {
             expect(typeof followersApi.remove).toBe('function');
-            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
-            followersApi.remove(relationshipId).finally(function() {
+            followersApi.remove(relationshipId).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use DELETE', function() {
@@ -133,13 +138,15 @@ describe('followers api', function() {
 
         it('should be defined', function(done) {
             expect(typeof followersApi.accept).toBe('function');
-            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
-            followersApi.accept(relationshipId, { status: 'following' }).finally(function() {
+            followersApi.accept(relationshipId, { status: 'following' }).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use PATCH', function() {

--- a/test/spec/api/groups.spec.js
+++ b/test/spec/api/groups.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/groups.spec.js
+++ b/test/spec/api/groups.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -21,13 +20,15 @@ describe('groups api', function() {
 
         it('be defined', function(done) {
             expect(typeof groupApi.list).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
-            groupApi.list(params).finally(function() {
+            groupApi.list(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -58,12 +59,14 @@ describe('groups api', function() {
 
         it('should be defined', function(done) {
             expect(typeof groupApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            groupApi.retrieve(123).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            groupApi.retrieve(123).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -93,7 +96,7 @@ describe('groups api', function() {
         linkLast = baseUrl + '/groups/?limit=5&reverse=true';
 
         function ajaxSpy() {
-            return spyOn(axios, 'request').and.returnValue(Bluebird.resolve({
+            return spyOn(axios, 'request').and.returnValue(Promise.resolve({
                 data: [],
                 headers: {
                     link: ['<' + linkNext + '>; rel="next"', '<' + linkLast + '>; rel="last"'].join(', '),
@@ -120,10 +123,12 @@ describe('groups api', function() {
             groupApi.list().then(function(page) {
                 return page.next();
             })
-            .finally(function() {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
                 done();
-            });
+            }
         });
 
         it('should get correct link on last()', function(done) {
@@ -132,10 +137,12 @@ describe('groups api', function() {
             groupApi.list().then(function(page) {
                 return page.last();
             })
-            .finally(function() {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
                 done();
-            });
+            }
         });
 
         it('should store the total document count', function(done) {

--- a/test/spec/api/institution-trees.spec.js
+++ b/test/spec/api/institution-trees.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/institution-trees.spec.js
+++ b/test/spec/api/institution-trees.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -21,12 +20,14 @@ describe('institution trees api', function() {
         };
 
         beforeEach(function(done) {
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            institutionTreesApi.list(params).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            institutionTreesApi.list(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should be defined', function() {
@@ -61,12 +62,14 @@ describe('institution trees api', function() {
         var ajaxRequest;
 
         beforeEach(function(done) {
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            institutionTreesApi.retrieve('123').finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            institutionTreesApi.retrieve('123').then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should be defined', function() {

--- a/test/spec/api/institutions.spec.js
+++ b/test/spec/api/institutions.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/institutions.spec.js
+++ b/test/spec/api/institutions.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -22,12 +21,14 @@ describe('institutions api', function() {
 
         it('should be defined', function(done) {
             expect(typeof institutionsApi.search).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            institutionsApi.search(params).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            institutionsApi.search(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -59,12 +60,14 @@ describe('institutions api', function() {
 
         it('should be defined', function(done) {
             expect(typeof institutionsApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            institutionsApi.retrieve('some-id').finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            institutionsApi.retrieve('some-id').then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {

--- a/test/spec/api/locations.spec.js
+++ b/test/spec/api/locations.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/locations.spec.js
+++ b/test/spec/api/locations.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -22,12 +21,14 @@ describe('locations api', function() {
 
         it('should be defined', function(done) {
             expect(typeof locationsApi.search).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            locationsApi.search(params).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            locationsApi.search(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -59,12 +60,14 @@ describe('locations api', function() {
 
         it('should be defined', function(done) {
             expect(typeof locationsApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            locationsApi.retrieve('some-id').finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            locationsApi.retrieve('some-id').then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {

--- a/test/spec/api/metadata.spec.js
+++ b/test/spec/api/metadata.spec.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -22,12 +21,14 @@ describe('metadata api', function() {
 
         it('should be defined', function(done) {
             expect(typeof metadataApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            metadataApi.retrieve(params).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            metadataApi.retrieve(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {

--- a/test/spec/api/metadata.spec.js
+++ b/test/spec/api/metadata.spec.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/profiles.spec.js
+++ b/test/spec/api/profiles.spec.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -13,7 +12,7 @@ describe('profiles api', function() {
       authFlow: mockAuth.mockImplicitGrantFlow()
     }).profiles;
 
-    var mockPromiseUpdate = Bluebird.resolve({
+    var mockPromiseUpdate = Promise.resolve({
         data: [],
         status: 200,
         headers: {
@@ -36,12 +35,14 @@ describe('profiles api', function() {
 
         it('should be defined', function(done) {
             expect(typeof profilesApi.me).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            profilesApi.me().finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            profilesApi.me().then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -73,12 +74,14 @@ describe('profiles api', function() {
 
         it('should be defined', function(done) {
             expect(typeof profilesApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            profilesApi.retrieve(123).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            profilesApi.retrieve(123).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -110,11 +113,13 @@ describe('profiles api', function() {
         it('should be defined', function(done) {
             expect(typeof profilesApi.update).toBe('function');
             var ajaxSpy = spyOn(axios, 'request').and.callFake(getMockPromises(mockPromiseUpdate));
-            profilesApi.update(requestData).finally(function() {
+            profilesApi.update(requestData).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use PATCH', function() {
@@ -144,12 +149,14 @@ describe('profiles api', function() {
         var ajaxRequest;
 
         beforeEach(function(done) {
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            profilesApi.retrieveByEmail('test@test.com').finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            profilesApi.retrieveByEmail('test@test.com').then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should be defined', function() {
@@ -181,7 +188,7 @@ describe('profiles api', function() {
         var ajaxSpy;
 
         beforeEach(function() {
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
         });
 
         it('should pass scopus id through to the api request', function(done) {
@@ -189,13 +196,15 @@ describe('profiles api', function() {
                 scopus_author_id: '12345'
             };
 
-            profilesApi.retrieveByIdentifier(params).finally(function() {
+            profilesApi.retrieveByIdentifier(params).then(_finally, _finally);
+
+            function _finally() {
                 var ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
 
                 expect(ajaxSpy).toHaveBeenCalled();
                 expect(ajaxRequest.params).toBe(params);
                 done();
-            });
+            }
         });
 
         it('should pass link paramter through to the api request', function(done) {
@@ -203,13 +212,15 @@ describe('profiles api', function() {
                 link: 'hermione-granger'
             };
 
-            profilesApi.retrieveByIdentifier(params).finally(function() {
+            profilesApi.retrieveByIdentifier(params).then(_finally, _finally);
+
+            function _finally() {
                 var ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
 
                 expect(ajaxSpy).toHaveBeenCalled();
                 expect(ajaxRequest.params).toBe(params);
                 done();
-            });
+            }
         });
     });
 

--- a/test/spec/api/profiles.spec.js
+++ b/test/spec/api/profiles.spec.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/subject-areas.js
+++ b/test/spec/api/subject-areas.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -23,13 +22,15 @@ describe('subject areas api', function() {
 
         it('be defined', function(done) {
             expect(typeof subjectAreasApi.list).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
-            subjectAreasApi.list(params).finally(function() {
+            subjectAreasApi.list(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {

--- a/test/spec/api/subject-areas.js
+++ b/test/spec/api/subject-areas.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/trash.spec.js
+++ b/test/spec/api/trash.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/api/trash.spec.js
+++ b/test/spec/api/trash.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -18,12 +17,14 @@ describe('trash api', function() {
 
         it('should be defined', function(done) {
             expect(typeof trashApi.retrieve).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            trashApi.retrieve(15).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            trashApi.retrieve(15).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -60,13 +61,15 @@ describe('trash api', function() {
 
         it('be defined', function(done) {
             expect(typeof trashApi.list).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
-            trashApi.list(sampleData).finally(function() {
+            trashApi.list(sampleData).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {
@@ -97,12 +100,14 @@ describe('trash api', function() {
 
         it('should be defined', function(done) {
             expect(typeof trashApi.restore).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            trashApi.restore(15).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            trashApi.restore(15).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use POST', function() {
@@ -130,7 +135,7 @@ describe('trash api', function() {
     describe('restore method failures', function() {
         it('should reject restore errors with the response', function(done) {
             var ajaxFailureResponse = function() {
-                return Bluebird.reject({ response: { status: 404 } });
+                return Promise.reject({ response: { status: 404 } });
             };
             spyOn(axios, 'request').and.callFake(ajaxFailureResponse);
             trashApi.restore().catch(function(error) {
@@ -146,12 +151,14 @@ describe('trash api', function() {
 
         it('should be defined', function(done) {
             expect(typeof trashApi.destroy).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
-            trashApi.destroy(15).finally(function() {
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
+            trashApi.destroy(15).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use DELETE', function() {
@@ -198,7 +205,7 @@ describe('trash api', function() {
                 headers.link = ['<' + linkNext + '>; rel="next"', '<' + linkLast + '>; rel="last"'].join(', ');
             }
 
-            spy.and.returnValue(Bluebird.resolve({
+            spy.and.returnValue(Promise.resolve({
                 headers: headers
             }));
             axios.request = spy;
@@ -224,10 +231,12 @@ describe('trash api', function() {
             trashApi.list().then(function(page) {
                 return page.next();
             })
-            .finally(function() {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkNext);
                 done();
-            });
+            }
         });
 
         it('should get correct link on last()', function(done) {
@@ -236,10 +245,12 @@ describe('trash api', function() {
             trashApi.list().then(function(page) {
                 return page.last();
             })
-            .finally(function() {
+            .then(_finally, _finally);
+
+            function _finally() {
                 expect(spy.calls.mostRecent().args[0].url).toEqual(linkLast);
                 done();
-            });
+            }
         });
 
         it('should store the total trashed documents count', function(done) {

--- a/test/spec/api/user-roles.spec.js
+++ b/test/spec/api/user-roles.spec.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');
@@ -23,13 +22,15 @@ describe('user roles api', function() {
 
         it('be defined', function(done) {
             expect(typeof userRolesApi.list).toBe('function');
-            ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.resolve({headers: {}}));
+            ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.resolve({headers: {}}));
 
-            userRolesApi.list(params).finally(function() {
+            userRolesApi.list(params).then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy).toHaveBeenCalled();
                 ajaxRequest = ajaxSpy.calls.mostRecent().args[0];
                 done();
-            });
+            }
         });
 
         it('should use GET', function() {

--- a/test/spec/api/user-roles.spec.js
+++ b/test/spec/api/user-roles.spec.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 var sdk = require('../../../');
 var baseUrl = 'https://api.mendeley.com';
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/auth/auth.spec.js
+++ b/test/spec/auth/auth.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 
 if (typeof process === 'object' && process + '' === '[object process]') {
     global.window = {};

--- a/test/spec/auth/auth.spec.js
+++ b/test/spec/auth/auth.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 
 if (typeof process === 'object' && process + '' === '[object process]') {
     global.window = {};
@@ -153,7 +152,7 @@ describe('auth', function() {
 
         it('should support refresh token URL', function() {
             var ajaxRequest;
-            var ajaxSpy = spyOn(axios, 'get').and.returnValue(Bluebird.resolve());
+            var ajaxSpy = spyOn(axios, 'get').and.returnValue(Promise.resolve());
             var win = mockWindow();
             var options = {win: win, clientId: 9999, refreshAccessTokenUrl: '/refresh'};
 
@@ -218,7 +217,7 @@ describe('auth', function() {
             });
 
             var accessToken = 'accessToken';
-            var ajaxSpy = spyOn(axios, 'post').and.returnValue(Bluebird.resolve({
+            var ajaxSpy = spyOn(axios, 'post').and.returnValue(Promise.resolve({
                 data: {
                     'access_token': accessToken
                 }
@@ -273,7 +272,7 @@ describe('auth', function() {
             var accessToken = 'accessToken';
             var refreshToken = 'newRefreshToken';
 
-            var ajaxSpy = spyOn(axios, 'post').and.returnValue(Bluebird.resolve({
+            var ajaxSpy = spyOn(axios, 'post').and.returnValue(Promise.resolve({
                 data: {
                     'access_token': accessToken,
                     'refresh_token': refreshToken

--- a/test/spec/pagination/pagination.spec.js
+++ b/test/spec/pagination/pagination.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assign = require('object-assign');
+var Promise = require('../../../lib/promise-proxy');
 var pagination = require('../../../lib/pagination');
 var Request = require('../../../lib/request');
 var mockAuth = require('../../mocks/auth');

--- a/test/spec/pagination/pagination.spec.js
+++ b/test/spec/pagination/pagination.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Bluebird = require('bluebird');
 var assign = require('object-assign');
 var pagination = require('../../../lib/pagination');
 var Request = require('../../../lib/request');
@@ -12,7 +11,7 @@ var authFlow = mockAuth.mockImplicitGrantFlow();
 describe('pagination', function() {
 
     var requestCreateSpy;
-    var responsePromise = Bluebird.resolve({
+    var responsePromise = Promise.resolve({
         headers: {
             Header: '123'
         },

--- a/test/spec/promise-proxy/promise-proxy.spec.js
+++ b/test/spec/promise-proxy/promise-proxy.spec.js
@@ -1,0 +1,46 @@
+/* jshint sub: true */
+'use strict';
+
+var ES6Promise = require('es6-promise-promise');
+var PromiseProxy = require('../../../lib/promise-proxy');
+
+describe('promise-proxy', function() {
+
+    describe('before setPromise', function() {
+
+        it('should return instances of the global Promise', function() {
+            var promise = new PromiseProxy(function() {});
+            var all = PromiseProxy.all([]);
+            var race = PromiseProxy.race([]);
+            var resolve = PromiseProxy.resolve();
+            var reject = PromiseProxy.reject();
+
+            expect(promise).toEqual(jasmine.any(Promise));
+            expect(all).toEqual(jasmine.any(Promise));
+            expect(race).toEqual(jasmine.any(Promise));
+            expect(resolve).toEqual(jasmine.any(Promise));
+            expect(reject).toEqual(jasmine.any(Promise));
+        });
+    });
+
+    describe('after setPromise', function() {
+
+        beforeAll(function() {
+            PromiseProxy.setPromise(ES6Promise);
+        });
+
+        it('should return instances of the custom promise', function() {
+            var promise = new PromiseProxy(function() {});
+            var all = PromiseProxy.all([]);
+            var race = PromiseProxy.race([]);
+            var resolve = PromiseProxy.resolve();
+            var reject = PromiseProxy.reject();
+            
+            expect(promise).toEqual(jasmine.any(ES6Promise));
+            expect(all).toEqual(jasmine.any(ES6Promise));
+            expect(race).toEqual(jasmine.any(ES6Promise));
+            expect(resolve).toEqual(jasmine.any(ES6Promise));
+            expect(reject).toEqual(jasmine.any(ES6Promise));
+        });
+    });
+});

--- a/test/spec/request/request.spec.js
+++ b/test/spec/request/request.spec.js
@@ -1,9 +1,8 @@
 'use strict';
 
 var axios = require('axios');
-var Bluebird = require('bluebird');
 
-Bluebird.onPossiblyUnhandledRejection(function() {});
+process.on('unhandledRejection', function() {});
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
@@ -36,13 +35,16 @@ describe('request', function() {
         } }, { authFlow: mockAuth.mockImplicitGrantFlow() });
 
         var fun = getMockPromises(
-            Bluebird.resolve({ status: 200, headers: {} })
+            Promise.resolve({ status: 200, headers: {} })
         );
         spyOn(axios, 'request').and.callFake(fun);
 
-        myRequest.send().finally(function() {
+        myRequest.send().then(_finally, _finally);
+
+        function _finally() {
             expect(myRequest.request.headers.hasOwnProperty('foo')).toBe(false);
-        }).finally(done);
+            done();
+        }
     });
 
     describe('authentication', function() {
@@ -50,14 +52,16 @@ describe('request', function() {
         it('should add optional accessToken to the Authorization header', function(done) {
             var myRequest = request.create({ method: 'get' }, { authFlow: mockAuth.mockImplicitGrantFlow() });
             var fun = getMockPromises(
-                Bluebird.resolve({ status: 200, headers: {} })
+                Promise.resolve({ status: 200, headers: {} })
             );
             spyOn(axios, 'request').and.callFake(fun);
 
-            myRequest.send().finally(function() {
-                expect(myRequest.request.headers.Authorization).toEqual('Bearer auth');
-            }).finally(done);
+            myRequest.send().then(_finally, _finally);
 
+            function _finally() {
+                expect(myRequest.request.headers.Authorization).toEqual('Bearer auth');
+                done();
+            }
         });
     });
 
@@ -67,8 +71,8 @@ describe('request', function() {
             var mockAuthInterface = mockAuth.mockAuthCodeFlow();
             var myRequest = request.create({ method: 'get' }, { authFlow: mockAuthInterface });
             var fun = getMockPromises(
-                Bluebird.reject({ response: { status: 401 } }), // Auth failure
-                Bluebird.resolve({ status: 200, headers: {} }) // Original request success
+                Promise.reject({ response: { status: 401 } }), // Auth failure
+                Promise.resolve({ status: 200, headers: {} }) // Original request success
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
             var authRefreshSpy = spyOn(mockAuthInterface, 'refreshToken').and.callThrough();
@@ -85,11 +89,11 @@ describe('request', function() {
             var mockAuthInterface = mockAuth.mockAuthCodeFlow();
             var myRequest = request.create({ method: 'get' }, { authFlow: mockAuthInterface });
             var fun = getMockPromises(
-                Bluebird.reject({ response: { status: 401 } }), // Auth failure
-                Bluebird.resolve({ status: 200, headers: {} }) // Original request success
+                Promise.reject({ response: { status: 401 } }), // Auth failure
+                Promise.resolve({ status: 200, headers: {} }) // Original request success
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
-            var authRefreshSpy = spyOn(mockAuthInterface, 'refreshToken').and.returnValue(Bluebird.reject({ status: 500 }));
+            var authRefreshSpy = spyOn(mockAuthInterface, 'refreshToken').and.returnValue(Promise.reject({ status: 500 }));
             var authAuthenticateSpy = spyOn(mockAuthInterface, 'authenticate').and.callThrough();
 
             myRequest.send().catch(function() {
@@ -104,7 +108,7 @@ describe('request', function() {
             var mockAuthInterface = mockAuth.mockAuthCodeFlow();
             var myRequest = request.create({ method: 'get' }, { maxAuthRetries: 2, authFlow: mockAuthInterface });
 
-            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.reject(mockAuth.unauthorisedError));
+            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.reject(mockAuth.unauthorisedError));
             var authRefreshSpy = spyOn(mockAuthInterface, 'refreshToken').and.callThrough();
             var authAuthenticateSpy = spyOn(mockAuthInterface, 'authenticate').and.callThrough();
 
@@ -112,16 +116,16 @@ describe('request', function() {
                 expect(ajaxSpy.calls.count()).toEqual(3);
                 expect(authRefreshSpy.calls.count()).toEqual(2);
                 expect(authAuthenticateSpy.calls.count()).toEqual(1);
-            }).finally(done);
+            }).then(done, done);
         });
 
         it('should NOT exceed maxAuthRetries for multiple requests', function(done) {
             var mockAuthInterface = mockAuth.slowAuthCodeFlow();
-            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Bluebird.reject(mockAuth.unauthorisedError));
+            var ajaxSpy = spyOn(axios, 'request').and.returnValue(Promise.reject(mockAuth.unauthorisedError));
             var authRefreshSpy = spyOn(mockAuthInterface, 'refreshToken').and.callThrough();
             var authAuthenticateSpy = spyOn(mockAuthInterface, 'authenticate').and.callThrough();
 
-            Bluebird.all([
+            Promise.all([
                 request.create({ method: 'get' }, { authFlow: mockAuthInterface }).send(),
                 request.create({ method: 'get' }, { authFlow: mockAuthInterface }).send()
             ]).catch(function() {
@@ -136,16 +140,16 @@ describe('request', function() {
             var mockAuthInterface = mockAuth.slowAuthCodeFlow();
             var ajaxSpy = spyOn(axios, 'request').and.callFake(function (config) {
                 if (config.headers.Authorization === 'Bearer auth-refreshed-1') {
-                    return Bluebird.resolve({ status: 200, headers: {} });
+                    return Promise.resolve({ status: 200, headers: {} });
                 }
 
-                return Bluebird.reject({
+                return Promise.reject({
                     response: mockAuth.unauthorisedError
                 });
             });
             var authRefreshSpy = spyOn(mockAuthInterface, 'refreshToken').and.callThrough();
 
-            Bluebird.all([
+            Promise.all([
                 request.create({ method: 'get' }, { authFlow: mockAuthInterface }).send(),
                 request.create({ method: 'get' }, { authFlow: mockAuthInterface }).send(),
                 request.create({ method: 'get' }, { authFlow: mockAuthInterface }).send(),
@@ -165,8 +169,8 @@ describe('request', function() {
             var refreshError = new Error('refresh error');
             var mockAuthInterface = mockAuth.mockAuthCodeFlow();
             var myRequest = request.create({ method: 'get' }, { authFlow: mockAuthInterface });
-            spyOn(axios, 'request').and.returnValue(Bluebird.reject({ response: { status: 401 } }));
-            spyOn(mockAuthInterface, 'refreshToken').and.returnValue(Bluebird.reject(refreshError));
+            spyOn(axios, 'request').and.returnValue(Promise.reject({ response: { status: 401 } }));
+            spyOn(mockAuthInterface, 'refreshToken').and.returnValue(Promise.reject(refreshError));
 
             myRequest.send().catch(function(caughtError) {
                 expect(refreshError).toEqual(caughtError);
@@ -179,37 +183,42 @@ describe('request', function() {
         it('should NOT retry by default', function(done) {
             var myRequest = request.create({ method: 'get' }, { authFlow: mockAuth.mockImplicitGrantFlow() });
             var fun = getMockPromises(
-                Bluebird.reject(mockAuth.unauthorisedError),
-                Bluebird.resolve({ status: 200, headers: {} })
+                Promise.reject(mockAuth.unauthorisedError),
+                Promise.resolve({ status: 200, headers: {} })
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
 
-            myRequest.send().finally(function() {
-                expect(ajaxSpy.calls.count()).toEqual(1);
-            }).finally(done);
+            myRequest.send().then(_finally, _finally);
 
+            function _finally() {
+                expect(ajaxSpy.calls.count()).toEqual(1);
+                done();
+            }
         });
 
         it('should allow setting maximum number of retries', function(done) {
             var myRequest = request.create({ method: 'get' }, { maxRetries: 1, authFlow: mockAuth.mockImplicitGrantFlow() });
             var fun = getMockPromises(
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.resolve({ status: 200, headers: {} })
+                Promise.reject(mockAuth.timeoutError),
+                Promise.resolve({ status: 200, headers: {} })
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
 
-            myRequest.send().finally(function() {
+            myRequest.send().then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy.calls.count()).toEqual(2);
-            }).finally(done);
+                done();
+            }
         });
 
 
         it('should NOT do more than maxRetries', function(done) {
             var myRequest = request.create({ method: 'get' }, { maxRetries: 1, authFlow: mockAuth.mockImplicitGrantFlow() });
             var fun = getMockPromises(
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.resolve({ status: 200, headers: {} })
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.resolve({ status: 200, headers: {} })
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
 
@@ -222,35 +231,37 @@ describe('request', function() {
         it('should correctly resolve the original deferred', function(done) {
             var myRequest = request.create({ method: 'get' }, { maxRetries: 10, authFlow: mockAuth.mockImplicitGrantFlow() });
             var fun = getMockPromises(
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.reject(mockAuth.timeoutError),
-                Bluebird.resolve({ status: 200, headers: {} })
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.reject(mockAuth.timeoutError),
+                Promise.resolve({ status: 200, headers: {} })
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
 
-            myRequest.send().finally(function() {
+            myRequest.send().then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy.calls.count()).toEqual(10);
                 done();
-            }).catch(function() {});
+            }
         });
 
         it('should not cache failing access token promises for single request', function(done) {
             var mockAuthInterface = mockAuth.mockAuthCodeFlow();
             var ajaxSpy = spyOn(axios, 'request').and.returnValues(
-                Bluebird.reject({ response: { status: 401 } }), // request auth fail
-                Bluebird.reject({ response: { status: 401 } }), // request auth fail
-                Bluebird.resolve({ status: 200, headers: {} }) // request success
+                Promise.reject({ response: { status: 401 } }), // request auth fail
+                Promise.reject({ response: { status: 401 } }), // request auth fail
+                Promise.resolve({ status: 200, headers: {} }) // request success
             );
             var refreshTokenSpy = spyOn(mockAuthInterface, 'refreshToken').and.returnValues(
-                Bluebird.reject({ response: { status: 401 } }), // token request fail
-                Bluebird.resolve({ status: 200, headers: {} }) // token request success
+                Promise.reject({ response: { status: 401 } }), // token request fail
+                Promise.resolve({ status: 200, headers: {} }) // token request success
             );
 
             request.create({ method: 'get' }, { authFlow: mockAuthInterface }).send()
@@ -274,41 +285,44 @@ describe('request', function() {
         it('should NOT retry on generic errors', function(done) {
             var myRequest = request.create({ method: 'get' }, { maxRetries: 1, authFlow: mockAuth.mockImplicitGrantFlow() });
             var fun = getMockPromises(
-                Bluebird.reject(mockAuth.notFoundError),
-                Bluebird.resolve({ status: 200, headers: {} })
+                Promise.reject(mockAuth.notFoundError),
+                Promise.resolve({ status: 200, headers: {} })
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
 
             myRequest.send().catch(function() {
                 expect(ajaxSpy.calls.count()).toEqual(1);
-            }).finally(done);
+            }).then(done, done);
         });
 
         it('should retry when a service is temporarily unavailable', function(done) {
             var myRequest = request.create({ method: 'get' }, { maxRetries: 5, authFlow: mockAuth.mockImplicitGrantFlow() });
             var fun = getMockPromises(
-                Bluebird.reject(mockAuth.unavailableError),
-                Bluebird.resolve({ status: 200, headers: {} })
+                Promise.reject(mockAuth.unavailableError),
+                Promise.resolve({ status: 200, headers: {} })
             );
             var ajaxSpy = spyOn(axios, 'request').and.callFake(fun);
 
-            myRequest.send().finally(function() {
+            myRequest.send().then(_finally, _finally);
+
+            function _finally() {
                 expect(ajaxSpy.calls.count()).toEqual(2);
-            }).finally(done);
+                done();
+            }
         });
 
         it('should survive vanilla Errors', function(done) {
             var error = new Error('Kaboom!');
             var myRequest = request.create({ method: 'get' }, { maxRetries: 1, authFlow: mockAuth.mockImplicitGrantFlow() });
             var fun = getMockPromises(
-                Bluebird.reject(error),
-                Bluebird.resolve({ status: 200, headers: {} })
+                Promise.reject(error),
+                Promise.resolve({ status: 200, headers: {} })
             );
             spyOn(axios, 'request').and.callFake(fun);
 
             myRequest.send().catch(function(e) {
                 expect(e).toEqual(error);
-            }).finally(done);
+            }).then(done, done);
         });
     });
 });

--- a/test/spec/request/request.spec.js
+++ b/test/spec/request/request.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var axios = require('axios');
+var Promise = require('../../../lib/promise-proxy');
 
 process.on('unhandledRejection', function() {});
 

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -5,6 +5,7 @@ describe('utilities', function() {
     var Request = require('../../../lib/request');
     var mockAuth = require('../../mocks/auth');
     var assign = require('object-assign');
+    var Promise = require('../../../lib/promise-proxy');
     var authFlow = mockAuth.mockImplicitGrantFlow();
     var requestCreateSpy;
 

--- a/test/spec/utilities/utilities.spec.js
+++ b/test/spec/utilities/utilities.spec.js
@@ -5,7 +5,6 @@ describe('utilities', function() {
     var Request = require('../../../lib/request');
     var mockAuth = require('../../mocks/auth');
     var assign = require('object-assign');
-    var Bluebird = require('bluebird');
     var authFlow = mockAuth.mockImplicitGrantFlow();
     var requestCreateSpy;
 
@@ -18,7 +17,7 @@ describe('utilities', function() {
         }
     };
 
-    var responsePromise = Bluebird.resolve({
+    var responsePromise = Promise.resolve({
         headers: {
             Header: '123'
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,5 @@
 var webpack = require('webpack');
-var plugins = [new webpack.ProvidePlugin({
-    Promise: 'bluebird'
-})];
+var plugins = [];
 var useMinifier = (process.argv.slice(1).indexOf('--minify') !== -1);
 
 if (useMinifier) {


### PR DESCRIPTION
This pull request removes the Bluebird dependency - a 78kb (27kb gzipped) weight.

~I've left the tests unchanged due to their use of `.finally()` but the actual lib code didn't need anything more than plain old ES6 Promises.~

I've refactored the tests, as well, to use native Promises.