### PR TITLE
Add different mime-type for a singular profile object

### DIFF
--- a/lib/api/profiles.js
+++ b/lib/api/profiles.js
@@ -26,7 +26,7 @@ module.exports = function profiles(options) {
             method: 'GET',
             resource: '/profiles/me',
             headers: {
-              Accept: MIME_TYPES.PROFILE
+              Accept: MIME_TYPES.PROFILES
             }
         }),
 
@@ -45,7 +45,7 @@ module.exports = function profiles(options) {
             resource: '/profiles/{id}',
             args: ['id'],
             headers: {
-              Accept: MIME_TYPES.PROFILE
+              Accept: MIME_TYPES.PROFILES
             }
         }),
 
@@ -64,7 +64,7 @@ module.exports = function profiles(options) {
             resource: '/profiles/me',
             headers: {
               'Content-Type': MIME_TYPES.PROFILE_UPDATE,
-              Accept: MIME_TYPES.PROFILE
+              Accept: MIME_TYPES.PROFILES
             },
             followLocation: true
         }),
@@ -84,7 +84,7 @@ module.exports = function profiles(options) {
             resource: '/profiles?email={email}',
             args: ['email'],
             headers: {
-                Accept: MIME_TYPES.PROFILE
+                Accept: MIME_TYPES.PROFILES
             }
         }),
 
@@ -103,7 +103,7 @@ module.exports = function profiles(options) {
             resource: '/profiles?link={link}',
             args: ['link'],
             headers: {
-                Accept: MIME_TYPES.PROFILE
+                Accept: MIME_TYPES.PROFILES
             }
         }),
 
@@ -121,7 +121,7 @@ module.exports = function profiles(options) {
             method: 'GET',
             resource: '/profiles',
             headers: {
-                Accept: MIME_TYPES.PROFILE
+                Accept: MIME_TYPES.PROFILES
             }
         })
 

--- a/lib/mime-types.js
+++ b/lib/mime-types.js
@@ -14,7 +14,8 @@ module.exports = {
     INSTITUTION: 'application/vnd.mendeley-institution.1+json',
     INSTITUTION_TREE: 'application/vnd.mendeley-institution-tree.1+json',
     LOCATION: 'application/vnd.mendeley-location.1+json',
-    PROFILE: 'application/vnd.mendeley-profiles.1+json',
+    PROFILE: 'application/vnd.mendeley-profile.1+json',
+    PROFILES: 'application/vnd.mendeley-profiles.1+json',
     PROFILE_UPDATE: 'application/vnd.mendeley-profile-amendment.1+json',
     SUBJECT_AREA: 'application/vnd.mendeley-subject-area.1+json',
     USER_ROLE: 'application/vnd.mendeley-user-role.1+json'


### PR DESCRIPTION
I missed this small detail in my [previous PR](https://github.com/Mendeley/mendeley-javascript-sdk/pull/107)

For some reason, the situation is like this:

`GET /profiles - application/vnd.mendeley-profiles.1+json`
`GET /search/profiles - application/vnd.mendeley-profile.1+json`